### PR TITLE
Optimizations in data import.

### DIFF
--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -277,8 +277,11 @@ class Sync(BrowserView):
                     # If it is list of json data dict of objects, add local
                     # uid to that dictionary. This local_uid can be used in
                     # Field Managers.
-                    if isinstance(item, dict) and item.get("uid"):
-                        value[i]['local_uid'] = uidmap.get(item.get("uid"))
+                    if isinstance(item, dict):
+                        for k, v in item.iteritems():
+                            if 'uid' in k:
+                                l_uid = uidmap.get(v)
+                                item[k] = l_uid
 
             # handle file fields
             if field.type in ("file", "image", "blob"):

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -150,6 +150,7 @@ class Sync(BrowserView):
             self.fetch_users(domain)
             # Start the fetch process beginning from the portal object
             self.fetch_data(domain, uid="0")
+            logger.info("*** FETCHING DATA FINISHED {} ***".format(domain))
 
         # always render the template
         return self.template()
@@ -241,7 +242,8 @@ class Sync(BrowserView):
                     # remember the UID -> object UID mapping for the update step
                     uidmap[uid] = api.get_uid(obj)
                     objmap[uid] = obj
-                    transaction.commit()
+
+        transaction.commit()
 
         # Update all objects with the given data
         for uid, obj_uid in uidmap.items():
@@ -250,6 +252,7 @@ class Sync(BrowserView):
             self.update_object_with_data(obj, datastore[uid], domain)
 
         self.reindex_updated_objects()
+        logger.info("*** END OF DATA IMPORT {} ***".format(domain))
 
     def update_object_with_data(self, obj, data, domain):
         """Update an existing object with data
@@ -338,6 +341,7 @@ class Sync(BrowserView):
     def fetch_users(self, domain):
         """Fetch all users from the source URL
         """
+        logger.info("*** FETCH USERS {} ***".format(domain))
         storage = self.get_storage(domain=domain)
         userstore = storage["users"]
 

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -6,10 +6,12 @@ import urllib
 import urlparse
 import requests
 import transaction
+from dateutil.parser import parse as parse_date
 
 from BTrees.OOBTree import OOSet
 from BTrees.OOBTree import OOBTree
 
+from Products.ATContentTypes.utils import dt2DT
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.CMFPlone.utils import _createObjectByType
@@ -224,6 +226,9 @@ class Sync(BrowserView):
                 existing = self.portal.unrestrictedTraverse(str(local_path), None)
 
                 if existing:
+                    r_modified = parse_date(data['modified'])
+                    if dt2DT(r_modified) < existing.modified():
+                        continue
                     # remember the UID -> object UID mapping for the update step
                     uidmap[uid] = api.get_uid(existing)
                     objmap[uid] = existing

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -188,7 +188,9 @@ class Sync(BrowserView):
         storage = self.get_storage(domain=domain)
         datastore = storage["data"]
         indexstore = storage["index"]
+        uidmap = storage["uidmap"]
         credentials = storage["credentials"]
+
         # At some points api cannot retrieve objects by UID in the end of
         # creation process. Thus we keep them in an dictionary to access easily.
         objmap = {}
@@ -230,6 +232,8 @@ class Sync(BrowserView):
                 existing = self.portal.unrestrictedTraverse(str(local_path), None)
 
                 if existing:
+                    # remember the UID -> object UID mapping for the update step
+                    uidmap[uid] = api.get_uid(existing)
                     objmap[uid] = existing
                 else:
                     # get the container object by path
@@ -237,6 +241,8 @@ class Sync(BrowserView):
                     container = self.portal.unrestrictedTraverse(str(container_path), None)
                     # create an object slug in this container
                     obj = self.create_object_slug(container, data)
+                    # remember the UID -> object UID mapping for the update step
+                    uidmap[uid] = api.get_uid(obj)
                     objmap[uid] = obj
 
         # When creation process is done, commit the transaction to avoid

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -274,9 +274,11 @@ class Sync(BrowserView):
                 value = self.dereference_object(value.get("uid"), uidmap)
             elif type(value) in (list, tuple):
                 for i, item in enumerate(value):
+                    # If it is list of json data dict of objects, add local
+                    # uid to that dictionary. This local_uid can be used in
+                    # Field Managers.
                     if isinstance(item, dict) and item.get("uid"):
-                        value[i] = self.dereference_object(item.get("uid"),
-                                                           uidmap)
+                        value[i]['local_uid'] = uidmap.get(item.get("uid"))
 
             # handle file fields
             if field.type in ("file", "image", "blob"):


### PR DESCRIPTION
**Current behavior**
During data import, some objects are skipped, or not created at all.
Some values of Reference Fields are not set because of wrong (remote) UIDs.
Reindexing is done after the object is updated. By this way it doesn't reindex other objects which has Relation with that object.

**Expected behavior after this PR**
Once object creation step is done, commit the transaction.
Instead of querying objects each time, try to get them from new `object map`.
Reindex all the objects when import is finished, so `BackReference` fields are set correctly too.  
