### PR TITLE
Add String Field Manager

### DIFF
--- a/src/senaite/sync/configure.zcml
+++ b/src/senaite/sync/configure.zcml
@@ -8,4 +8,15 @@
   <!-- include packages -->
   <include package=".browser" />
 
+  <!-- AT FIELD MANAGERS
+       Field level interface to get and set values and get a JSON compatible
+       structure of the value.
+  -->
+
+  <!-- Adapter for AT Fields -->
+  <adapter
+      for="Products.Archetypes.interfaces.field.IStringField"
+      factory=".fieldmanagers.StringFieldManager"
+      />
+
 </configure>

--- a/src/senaite/sync/fieldmanagers.py
+++ b/src/senaite/sync/fieldmanagers.py
@@ -17,7 +17,8 @@ class StringFieldManager(ATFieldManager):
         """Set the value of the field
         """
         if value is None:
-            value = ''
             if self.field.multiValued:
                 value = []
+            else:
+                value = ''
         return self._set(instance, value, **kw)

--- a/src/senaite/sync/fieldmanagers.py
+++ b/src/senaite/sync/fieldmanagers.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2017 SENAITE LIMS.
+
+from zope import interface
+
+from senaite.jsonapi.fieldmanagers import ATFieldManager
+from senaite.jsonapi.interfaces import IFieldManager
+
+
+class StringFieldManager(ATFieldManager):
+    """Adapter to set/get the value of String Fields
+    """
+    interface.implements(IFieldManager)
+
+    def set(self, instance, value, **kw):
+        """Set the value of the field
+        """
+        if value is None:
+            value = ''
+        return self._set(instance, value, **kw)

--- a/src/senaite/sync/fieldmanagers.py
+++ b/src/senaite/sync/fieldmanagers.py
@@ -18,4 +18,6 @@ class StringFieldManager(ATFieldManager):
         """
         if value is None:
             value = ''
+            if self.field.multiValued:
+                value = []
         return self._set(instance, value, **kw)


### PR DESCRIPTION
## Current behavior
When importing data the value assigned to empty StringFields is ```None```. This results in several errors on the target instance because the expected StringField value when it has no value assigned is and empty string. 

## Expected behavior after this PR
StringFields are set an empty string (`''`) when its value is not set. 
