### PR TITLE
Import error in "views.py".

### DIFF
--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -32,7 +32,7 @@ from senaite.sync import logger
 from senaite.sync.browser.interfaces import ISync
 from senaite.sync import _
 
-from src.senaite.jsonapi.fieldmanagers import ProxyFieldManager
+from senaite.jsonapi.fieldmanagers import ProxyFieldManager
 
 API_BASE_URL = "API/senaite/v1"
 SYNC_STORAGE = "senaite.sync"


### PR DESCRIPTION
**Current Behavior**
When starting an instance with Sync add-on installed, it fails because of import error.

**Expected Behavior after this PR**
Import doesn't fail.

P.S: No idea where that "src" comes from...