### PR TITLE
Periodic Auto Sync

### DIFF
--- a/src/senaite/sync/browser/configure.zcml
+++ b/src/senaite/sync/browser/configure.zcml
@@ -16,4 +16,11 @@
       permission="cmf.ManagePortal"
       />
 
+  <browser:page
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      name="edit_auto_sync"
+      class=".views.EditAutoSync"
+      permission="cmf.ManagePortal"
+      />
+
 </configure>

--- a/src/senaite/sync/browser/configure.zcml
+++ b/src/senaite/sync/browser/configure.zcml
@@ -9,4 +9,11 @@
       permission="cmf.ManagePortal"
       />
 
+  <browser:page
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      name="do_auto_sync"
+      class=".views.AutoSync"
+      permission="cmf.ManagePortal"
+      />
+
 </configure>

--- a/src/senaite/sync/browser/templates/edit_sync_domains.pt
+++ b/src/senaite/sync/browser/templates/edit_sync_domains.pt
@@ -23,107 +23,149 @@
     <div metal:fill-slot="content-core"
          tal:define="portal context/@@plone_portal_state/portal;">
 
-      <form id="add_domain"
-            name="add_domain"
-            method="POST">
 
-        <input type="hidden" name="add_domain" value="1"/>
-        <span tal:replace="structure context/@@authenticator/authenticator"/>
 
-        <!-- Base URL -->
-        <div class="field form-group field">
-          <label i18n:translate=""
-                 class="form-control-label"
-                 for="domain_name">
-            Domain Name (ID)
-            <span class="required"></span>
-            <span i18n:translate=""
-                  class="help formHelp">
-              Unique name for the domain.
-            </span>
-          </label>
-          <div class="form-group input-group">
-            <span class="input-group-addon"><i class="glyphicon glyphicon-link"></i></span>
-            <input type="text" size="30"
-                   class="form-control"
-                   id="domain_name"
-                   name="domain_name"/>
-          </div>
-        </div>
+      <h2>Domains</h2>
+      <table class="table listing collapsibleContent">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>URL</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr tal:define="data view/get_domains"
+              tal:repeat="key python:data.keys()">
+            <td>
+              <span tal:content="python:key"></span>
+            </td>
+            <td>
+                <span tal:content="python: data[key]['url']"/>
+            </td>
+            <td>
+                <form id="remove_domain" name="remove_domain" method="POST">
+                    <input type="hidden" name="remove_domain" value="1"/>
+                    <input type="hidden" name="domain_name"
+                           tal:attributes="value key"/>
+                    <input class="btn btn-delete btn-sm"
+                       type="submit"
+                       name="btn_remove_domain"
+                       i18n:attributes="value"
+                       value="Remove"/>
+                </form>
+            </td>
+          </tr>
+        </tbody>
+      </table>
 
-        <div class="field form-group field">
-          <label i18n:translate=""
-                 class="form-control-label"
-                 for="url">
-            Source URL
-            <span class="required"></span>
-            <span i18n:translate=""
-                  class="help formHelp">
-              The base URL of the source system, e.g. http://localhost:1337/senaitelims
-            </span>
-          </label>
-          <div class="form-group input-group">
-            <span class="input-group-addon"><i class="glyphicon glyphicon-link"></i></span>
-            <input type="text" size="30"
-                   class="form-control"
-                   id="url"
-                   name="url"/>
-          </div>
-        </div>
+      <dl class="collapsible default-closed">
+          <dt class="collapsibleHeader">
+              <h3>Add new Domain</h3>
+          </dt>
+          <dd class="collapsibleContent">
+              <form id="add_domain"
+                    name="add_domain"
+                    method="POST">
 
-        <!-- Username -->
-        <div class="field form-group field">
-          <label i18n:translate=""
-                 class="form-control-label"
-                 for="ac_username">
-            Username
-            <span class="required"></span>
-            <span i18n:translate=""
-                  class="help formHelp">
-              The username to login into the source system
-            </span>
-          </label>
-          <div class="form-group input-group">
-            <span class="input-group-addon"><i class="glyphicon glyphicon-user"></i></span>
-            <input type="text"
-                   size="30"
-                   autocomplete="new-username"
-                   class="form-control"
-                   id="ac_username"
-                   name="ac_username"/>
-          </div>
-        </div>
+                <input type="hidden" name="add_domain" value="1"/>
+                <span tal:replace="structure context/@@authenticator/authenticator"/>
 
-        <!-- Password -->
-        <div class="field form-group field">
-          <label i18n:translate=""
-                 class="form-control-label"
-                 for="ac_password">
-            Password
-            <span class="required"></span>
-            <span i18n:translate=""
-                  class="help formHelp">
-              The password to login into the source system
-            </span>
-          </label>
-          <div class="form-group input-group">
-            <span class="input-group-addon"><i class="glyphicon glyphicon-lock"></i></span>
-            <input type="password"
-                   autocomplete="new-password"
-                   size="30"
-                   class="form-control"
-                   id="ac_password"
-                   name="ac_password"/>
-          </div>
-        </div>
+                <!-- Base URL -->
+                <div class="field form-group field">
+                  <label i18n:translate=""
+                         class="form-control-label"
+                         for="domain_name">
+                    Domain Name (ID)
+                    <span class="required"></span>
+                    <span i18n:translate=""
+                          class="help formHelp">
+                      Unique name for the domain.
+                    </span>
+                  </label>
+                  <div class="form-group input-group">
+                    <span class="input-group-addon"><i class="glyphicon glyphicon-link"></i></span>
+                    <input type="text" size="30"
+                           class="form-control"
+                           id="domain_name"
+                           name="domain_name"/>
+                  </div>
+                </div>
 
-        <input class="btn btn-success btn-sm"
-               type="submit"
-               name="btn_add_domain"
-               i18n:attributes="value"
-               value="Add Domain"/>
-      </form>
+                <div class="field form-group field">
+                  <label i18n:translate=""
+                         class="form-control-label"
+                         for="url">
+                    Source URL
+                    <span class="required"></span>
+                    <span i18n:translate=""
+                          class="help formHelp">
+                      The base URL of the source system, e.g. http://localhost:1337/senaitelims
+                    </span>
+                  </label>
+                  <div class="form-group input-group">
+                    <span class="input-group-addon"><i class="glyphicon glyphicon-link"></i></span>
+                    <input type="text" size="30"
+                           class="form-control"
+                           id="url"
+                           name="url"/>
+                  </div>
+                </div>
 
+                <!-- Username -->
+                <div class="field form-group field">
+                  <label i18n:translate=""
+                         class="form-control-label"
+                         for="ac_username">
+                    Username
+                    <span class="required"></span>
+                    <span i18n:translate=""
+                          class="help formHelp">
+                      The username to login into the source system
+                    </span>
+                  </label>
+                  <div class="form-group input-group">
+                    <span class="input-group-addon"><i class="glyphicon glyphicon-user"></i></span>
+                    <input type="text"
+                           size="30"
+                           autocomplete="new-username"
+                           class="form-control"
+                           id="ac_username"
+                           name="ac_username"/>
+                  </div>
+                </div>
+
+                <!-- Password -->
+                <div class="field form-group field">
+                  <label i18n:translate=""
+                         class="form-control-label"
+                         for="ac_password">
+                    Password
+                    <span class="required"></span>
+                    <span i18n:translate=""
+                          class="help formHelp">
+                      The password to login into the source system
+                    </span>
+                  </label>
+                  <div class="form-group input-group">
+                    <span class="input-group-addon"><i class="glyphicon glyphicon-lock"></i></span>
+                    <input type="password"
+                           autocomplete="new-password"
+                           size="30"
+                           class="form-control"
+                           id="ac_password"
+                           name="ac_password"/>
+                  </div>
+                </div>
+
+                <input class="btn btn-success btn-sm"
+                       type="submit"
+                       name="btn_add_domain"
+                       i18n:attributes="value"
+                       value="Add"/>
+              </form>
+          </dd>
+        </dl>
     </div>
 
   </body>

--- a/src/senaite/sync/browser/templates/edit_sync_domains.pt
+++ b/src/senaite/sync/browser/templates/edit_sync_domains.pt
@@ -1,0 +1,130 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="senaite">
+  <head>
+    <metal:block fill-slot="javascript_head_slot"
+                 tal:define="portal context/@@plone_portal_state/portal;">
+    </metal:block>
+  </head>
+  <body>
+
+    <metal:title fill-slot="content-title">
+      <h1 i18n:translate="">
+        SENAITE SYNC EDIT VIEW
+      </h1>
+    </metal:title>
+    <metal:description fill-slot="content-description">
+      <p i18n:translate="">
+      </p>
+    </metal:description>
+
+    <div metal:fill-slot="content-core"
+         tal:define="portal context/@@plone_portal_state/portal;">
+
+      <form id="add_domain"
+            name="add_domain"
+            method="POST">
+
+        <input type="hidden" name="add_domain" value="1"/>
+        <span tal:replace="structure context/@@authenticator/authenticator"/>
+
+        <!-- Base URL -->
+        <div class="field form-group field">
+          <label i18n:translate=""
+                 class="form-control-label"
+                 for="domain_name">
+            Domain Name (ID)
+            <span class="required"></span>
+            <span i18n:translate=""
+                  class="help formHelp">
+              Unique name for the domain.
+            </span>
+          </label>
+          <div class="form-group input-group">
+            <span class="input-group-addon"><i class="glyphicon glyphicon-link"></i></span>
+            <input type="text" size="30"
+                   class="form-control"
+                   id="domain_name"
+                   name="domain_name"/>
+          </div>
+        </div>
+
+        <div class="field form-group field">
+          <label i18n:translate=""
+                 class="form-control-label"
+                 for="url">
+            Source URL
+            <span class="required"></span>
+            <span i18n:translate=""
+                  class="help formHelp">
+              The base URL of the source system, e.g. http://localhost:1337/senaitelims
+            </span>
+          </label>
+          <div class="form-group input-group">
+            <span class="input-group-addon"><i class="glyphicon glyphicon-link"></i></span>
+            <input type="text" size="30"
+                   class="form-control"
+                   id="url"
+                   name="url"/>
+          </div>
+        </div>
+
+        <!-- Username -->
+        <div class="field form-group field">
+          <label i18n:translate=""
+                 class="form-control-label"
+                 for="ac_username">
+            Username
+            <span class="required"></span>
+            <span i18n:translate=""
+                  class="help formHelp">
+              The username to login into the source system
+            </span>
+          </label>
+          <div class="form-group input-group">
+            <span class="input-group-addon"><i class="glyphicon glyphicon-user"></i></span>
+            <input type="text"
+                   size="30"
+                   autocomplete="new-username"
+                   class="form-control"
+                   id="ac_username"
+                   name="ac_username"/>
+          </div>
+        </div>
+
+        <!-- Password -->
+        <div class="field form-group field">
+          <label i18n:translate=""
+                 class="form-control-label"
+                 for="ac_password">
+            Password
+            <span class="required"></span>
+            <span i18n:translate=""
+                  class="help formHelp">
+              The password to login into the source system
+            </span>
+          </label>
+          <div class="form-group input-group">
+            <span class="input-group-addon"><i class="glyphicon glyphicon-lock"></i></span>
+            <input type="password"
+                   autocomplete="new-password"
+                   size="30"
+                   class="form-control"
+                   id="ac_password"
+                   name="ac_password"/>
+          </div>
+        </div>
+
+        <input class="btn btn-success btn-sm"
+               type="submit"
+               name="btn_add_domain"
+               i18n:attributes="value"
+               value="Add Domain"/>
+      </form>
+
+    </div>
+
+  </body>
+</html>

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -79,8 +79,15 @@ class EditAutoSync(BrowserView):
         form = self.request.form
         if form.get("add_domain", False):
             self.add_new_credential(form)
+        elif form.get("remove_domain", False):
+            name = form.get("domain_name")
+            self.remove_domain(name)
 
         return self.template()
+
+    def get_domains(self):
+        storage = get_credentials_storage(self.portal)
+        return storage
 
     def add_new_credential(self, data):
         """
@@ -113,6 +120,7 @@ class EditAutoSync(BrowserView):
         storage = get_credentials_storage(self.portal)
         if storage.get(domain_name, False):
             del storage[domain_name]
+            logger.info("Domain Removed: {}".format(domain_name))
 
     def reset(self):
         """Drop the whole storage of credentials


### PR DESCRIPTION
**AUTO SYNC FUNCTIONALITY**
In order to make synchronisation more useful, a new functionality will be added by this PR. Instead of fetching and importing data from browser view manually, it can be done by the instance itself periodically with the credentials entered by _admin_ previously. 

**How to Enable**
________________________________________________________________________
 _Adding Clock Server_
In order to enable this new functionality, a `clock server` can be added to the instance. To do so,
a new `.cfg` file must be extended from the main `buildout.cfg` file of the instance. The `.cfg` file must contain the following lines:
```
[instance]
zope-conf-additional +=
    <clock-server>
       method /<site_name>/do_auto_sync
       period <period_in_seconds>
       user <username>
       password <password>
       host <site_url>
    </clock-server>
```
E.g:
```
[instance]
zope-conf-additional +=
    <clock-server>
       method /Plone/do_auto_sync
       period 86400
       user labman
       password labman
       host localhost:8080
    </clock-server>
```
___________________________________________________________________________

_Adding Domains_
Once clock server is done, calls to auto sync will be performed. Now it is time to add some domain to retrieve the data. This can be done from new browser view. Just add `edit_auto_sync` to the end of the site URL (e.g: http://localhost:8080/Plone/edit_auto_sync), and enter the domains in the displayed form. From the view, users with enough privileges can see existing domains, as well as delete any of them. Domains view is as simple as shown in the screenshot below:

![image](https://user-images.githubusercontent.com/23520079/34437640-51d2f43e-eca0-11e7-9e5f-eb3561e632c3.png)
___________________________________________________________________________
