### PR TITLE
Import mail settings 

### DIFF
--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -184,7 +184,7 @@
                 <thead>
                   <tr>
                     <th>Keyword</th>
-                    <th>Records and Values</th>
+                    <th>Records</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -197,6 +197,26 @@
                       <tal:values repeat="value python:data[key]">
                         <span tal:content="value"/>&nbsp;
                       </tal:values>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <h3>Mail settings</h3>
+              <table class="table listing collapsibleContent">
+                <thead>
+                  <tr>
+                    <th>Setting</th>
+                    <th>Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr tal:define="data python:view.storage[storage]['mailsettings']"
+                      tal:repeat="key python:data.keys()">
+                    <td>
+                      <span tal:content="python:key"></span>
+                    </td>
+                    <td>
+                      <span tal:content="python:data[key]"></span>
                     </td>
                   </tr>
                 </tbody>

--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -184,7 +184,7 @@
                 <thead>
                   <tr>
                     <th>Keyword</th>
-                    <th>Records</th>
+                    <th>Records and Values</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -165,7 +165,7 @@ class Sync(BrowserView):
         return self.template()
 
     def import_mail_settings(self, domain):
-        """Import the mail control panel configuration settings
+        """Import mail settings
         """
         logger.info("*** IMPORT MAIL CONFIGURATION {} ***".format(domain))
         storage = self.get_storage(domain=domain)

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -173,7 +173,7 @@ class Sync(BrowserView):
         # retrieve the objects that contain the mail settings
         mail_host = ploneapi.portal.get_tool(name='MailHost')
         portal = api.get_portal()
-        # for each of the values fetched from source try to set it 
+        # for each of the values fetched from source try to set it
         for key, value in dict(mail_settings_store).items():
             if hasattr(mail_host, key):
                 setattr(mail_host, key, value)

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -170,15 +170,14 @@ class Sync(BrowserView):
         logger.info("*** IMPORT MAIL CONFIGURATION {} ***".format(domain))
         storage = self.get_storage(domain=domain)
         mail_settings_store = storage["mailsettings"]
-
+        # retrieve the objects that contain the mail settings
         mail_host = ploneapi.portal.get_tool(name='MailHost')
         portal = api.get_portal()
-
+        # for each of the values fetched from source try to set it 
         for key, value in dict(mail_settings_store).items():
-            # Check if the key corresponds to a config value of the mail host
-            if key in vars(mail_host):
+            if hasattr(mail_host, key):
                 setattr(mail_host, key, value)
-            else:
+            elif hasattr(portal, key):
                 setattr(portal, key, value)
 
 

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -157,6 +157,7 @@ class Sync(BrowserView):
             self.fetch_data(domain, uid="0")
             # Fetch registry records that contain the word bika or senaite
             self.fetch_registry_records(domain, keys=["bika", "senaite"])
+            self.fetch_mail_settings(domain)
             logger.info("*** FETCHING DATA FINISHED {} ***".format(domain))
 
         # always render the template
@@ -493,6 +494,17 @@ class Sync(BrowserView):
             for record in retrieved_records[key][0].keys():
                 registry_store[key][record] = retrieved_records[key][0][record]
 
+    def fetch_mail_settings(self, domain):
+        """Fetch mail settings
+        """
+        logger.info("*** FETCH MAIL SETTINGS {} ***".format(domain))
+        storage = self.get_storage(domain=domain)
+        mailsettings_store = storage["mailsettings"]
+        settings = self.get_items("mailsettings")
+        import pdb; pdb.set_trace()
+        for key, val in settings[0]:
+            mailsettings_store[key] = val
+
     def fetch_users(self, domain):
         """Fetch all users from the source URL
         """
@@ -682,6 +694,7 @@ class Sync(BrowserView):
             self.storage[domain]["uidmap"] = OOBTree()
             self.storage[domain]["credentials"] = OOBTree()
             self.storage[domain]["registry"] = OOBTree()
+            self.storage[domain]["mailsettings"] = OOBTree()
         return self.storage[domain]
 
     def reindex_updated_objects(self):

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -101,6 +101,7 @@ class Sync(BrowserView):
             domain = form.get("domain", None)
             self.import_registry_records(domain)
             self.import_users(domain)
+            self.import_mail_settings(domain)
             self.import_data(domain)
             logger.info("*** END OF DATA IMPORT {} ***".format(domain))
             return self.template()
@@ -162,6 +163,24 @@ class Sync(BrowserView):
 
         # always render the template
         return self.template()
+
+    def import_mail_settings(self, domain):
+        """Import the mail control panel configuration settings
+        """
+        logger.info("*** IMPORT MAIL CONFIGURATION {} ***".format(domain))
+        storage = self.get_storage(domain=domain)
+        mail_settings_store = storage["mailsettings"]
+
+        mail_host = ploneapi.portal.get_tool(name='MailHost')
+        portal = api.get_portal()
+
+        for key, value in dict(mail_settings_store).items():
+            # Check if the key corresponds to a config value of the mail host
+            if key in vars(mail_host):
+                setattr(mail_host, key, value)
+            else:
+                setattr(portal, key, value)
+
 
     def import_registry_records(self, domain):
         """Import the registry records from the storage identified by domain

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -501,8 +501,7 @@ class Sync(BrowserView):
         storage = self.get_storage(domain=domain)
         mailsettings_store = storage["mailsettings"]
         settings = self.get_items("mailsettings")
-        import pdb; pdb.set_trace()
-        for key, val in settings[0]:
+        for key, val in settings[0].items():
             mailsettings_store[key] = val
 
     def fetch_users(self, domain):


### PR DESCRIPTION
Superseeded by: #12 
Related PR: https://github.com/senaite/senaite.jsonapi/pull/10

## Description of the issue/feature this PR addresses

Add functionality for fetching and importing/syncing the mail settings between two instances. The imported mail settings are:
```
__ac_local_roles__
email_from_address
email_from_name
force_tls
id
smtp_host
smtp_port
smtp_pwd
smtp_queue
smtp_queue_directory
smtp_uid
title
```

Which correspond mainly to the mail settings that can be observed in the mail settings view:

![mail_config](https://user-images.githubusercontent.com/9968427/34765200-308939b4-f5f1-11e7-8d26-41f2bc28783e.png)


## Current behavior before PR

Mail settings were not being imported/synced

## Desired behavior after PR is merged

Mail settings are imported/synced properly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html

  