### PR TITLE
Skip records not found in target instance registry

### DIFF
--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -174,9 +174,11 @@ class Sync(BrowserView):
         # import the records that were found
         for key in registry_store.keys():
             records = registry_store[key]
-            for record in records.keys():
+            for record in records:
                 logger.info("Updating record {} with value {}".format(record, records.get(record)))
-                current_registry[record] = records.get(record)
+                record_value = records.get(record)
+                if record in current_registry.records and record_value is not None:
+                    current_registry[record] = records.get(record)
 
     def import_users(self, domain):
         """Import the users from the storage identified by domain

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -178,7 +178,7 @@ class Sync(BrowserView):
                 logger.info("Updating record {} with value {}".format(record, records.get(record)))
                 record_value = records.get(record)
                 if record in current_registry.records and record_value is not None:
-                    current_registry[record] = records.get(record)
+                    current_registry[record] = record_value
 
     def import_users(self, domain):
         """Import the users from the storage identified by domain

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -176,9 +176,10 @@ class Sync(BrowserView):
             records = registry_store[key]
             for record in records:
                 logger.info("Updating record {} with value {}".format(record, records.get(record)))
-                record_value = records.get(record)
-                if record in current_registry.records and record_value is not None:
-                    current_registry[record] = record_value
+                if record not in current_registry.records:
+                    logger.warn("Current Registry has no record named {}".format(record))
+                    continue
+                current_registry[record] = records.get(record)
 
     def import_users(self, domain):
         """Import the users from the storage identified by domain


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When a record was not found in the target instance registry the following error was being raised:
```
Traceback (innermost last):

    Module ZPublisher.Publish, line 138, in publish
    Module ZPublisher.mapply, line 77, in mapply
    Module ZPublisher.Publish, line 48, in call_object
    Module senaite.sync.browser.views, line 102, in __call__
    Module senaite.sync.browser.views, line 179, in import_registry_records
    Module plone.registry.registry, line 47, in __setitem__
    Module plone.registry.registry, line 212, in __getitem__
    Module plone.registry.registry, line 269, in _getField

KeyError: u'bika.lims.current_coa_number'
``` 

## Current behavior before PR

Records import failed if a record from the source instance registry was missing in the target instance registry

## Desired behavior after PR is merged

Records that aren't found are skipped and no error is raised

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html