### PR TITLE
Settings import

### DIFF
--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -160,28 +160,6 @@
                      name="clear_storage"
                      i18n:attributes="value"
                      value="Clear this Storage"/>
-              <h3>Settings</h3>
-              <table class="table listing collapsibleContent">
-                <thead>
-                  <tr>
-                    <th>Key</th>
-                    <th>Schema</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr tal:define="data python:view.storage[storage]['settings']"
-                      tal:repeat="key python:data.keys()">
-                    <td>
-                      <span tal:content="python:key"></span>
-                    </td>
-                    <td>
-                      <tal:values repeat="value python:data[key]">
-                        <span tal:content="value"/>&nbsp;
-                      </tal:values>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
             </dd>
           </dl>
         </form>

--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -201,6 +201,28 @@
                   </tr>
                 </tbody>
               </table>
+              <h3>Settings</h3>
+              <table class="table listing collapsibleContent">
+                <thead>
+                  <tr>
+                    <th>Key</th>
+                    <th>Schema</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr tal:define="data python:view.storage[storage]['settings']"
+                      tal:repeat="key python:data.keys()">
+                    <td>
+                      <span tal:content="python:key"></span>
+                    </td>
+                    <td>
+                      <tal:values repeat="value python:data[key]">
+                        <span tal:content="value"/>&nbsp;
+                      </tal:values>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
               <h3>Content</h3>
               <table class="table listing collapsibleContent">
                 <thead>

--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -160,6 +160,28 @@
                      name="clear_storage"
                      i18n:attributes="value"
                      value="Clear this Storage"/>
+              <h3>Settings</h3>
+              <table class="table listing collapsibleContent">
+                <thead>
+                  <tr>
+                    <th>Key</th>
+                    <th>Schema</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr tal:define="data python:view.storage[storage]['settings']"
+                      tal:repeat="key python:data.keys()">
+                    <td>
+                      <span tal:content="python:key"></span>
+                    </td>
+                    <td>
+                      <tal:values repeat="value python:data[key]">
+                        <span tal:content="value"/>&nbsp;
+                      </tal:values>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
             </dd>
           </dl>
         </form>

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -490,10 +490,6 @@ class Sync(BrowserView):
             for key in setting_dict.keys():
                 settings_store[key] = setting_dict[key]
 
-        import pdb; pdb.set_trace()
-
-
-
     def fetch_registry_records(self, domain, keys=None):
         """Fetch configuration registry records of interest (those associated
         to the keywords passed) from source instance

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -39,6 +39,29 @@ from senaite.jsonapi.fieldmanagers import ProxyFieldManager
 API_BASE_URL = "API/senaite/v1"
 SYNC_STORAGE = "senaite.sync"
 
+CONTROLPANEL_INTERFACE_MAPPING = {
+    'mail': [cp.mail.IMailSchema],
+    'calendar': [cp.calendar.ICalendarSchema],
+    'ram': [cp.ram.IRAMCacheSchema],
+    'language': [cp.language.ILanguageSelectionSchema],
+    'editing': [cp.editing.IEditingSchema],
+    'usergroups': [cp.usergroups.IUserGroupsSettingsSchema,
+                   cp.usergroups.ISecuritySchema, ],
+    'search': [cp.search.ISearchSchema],
+    'filter': [cp.filter.IFilterAttributesSchema,
+               cp.filter.IFilterEditorSchema,
+               cp.filter.IFilterSchema,
+               cp.filter.IFilterTagsSchema],
+    'maintenance': [cp.maintenance.IMaintenanceSchema],
+    'markup': [cp.markup.IMarkupSchema,
+               cp.markup.ITextMarkupSchema,
+               cp.markup.IWikiMarkupSchema, ],
+    'navigation': [cp.navigation.INavigationSchema],
+    'security': [cp.security.ISecuritySchema],
+    'site': [cp.site.ISiteSchema],
+    'skins': [cp.skins.ISkinsSchema],
+}
+
 
 class SyncError(Exception):
     """ Exception Class for Sync Errors
@@ -179,30 +202,8 @@ class Sync(BrowserView):
     def set_settings(self, key, data):
         """Set settings by key
         """
-        key_to_ischema = {
-            'mail': [cp.mail.IMailSchema],
-            'calendar': [cp.calendar.ICalendarSchema],
-            'ram': [cp.ram.IRAMCacheSchema],
-            'language': [cp.language.ILanguageSelectionSchema],
-            'editing': [cp.editing.IEditingSchema],
-            'usergroups': [cp.usergroups.IUserGroupsSettingsSchema,
-                           cp.usergroups.ISecuritySchema, ],
-            'search': [cp.search.ISearchSchema],
-            'filter': [cp.filter.IFilterAttributesSchema,
-                       cp.filter.IFilterEditorSchema,
-                       cp.filter.IFilterSchema,
-                       cp.filter.IFilterTagsSchema],
-            'maintenance': [cp.maintenance.IMaintenanceSchema],
-            'markup': [cp.markup.IMarkupSchema,
-                       cp.markup.ITextMarkupSchema,
-                       cp.markup.IWikiMarkupSchema, ],
-            'navigation': [cp.navigation.INavigationSchema],
-            'security': [cp.security.ISecuritySchema],
-            'site': [cp.site.ISiteSchema],
-            'skins': [cp.skins.ISkinsSchema],
-        }
         # Get the Schema interface of the settings being imported
-        ischemas = key_to_ischema[key]
+        ischemas = CONTROLPANEL_INTERFACE_MAPPING[key]
         for ischema_name in data.keys():
             ischema = None
             for candidate_schema in ischemas:

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -163,6 +163,11 @@ class Sync(BrowserView):
         # always render the template
         return self.template()
 
+    def import_settings(self, domain):
+        """Import the settings from the storage identified by domain
+        """
+        pass
+
     def import_registry_records(self, domain):
         """Import the registry records from the storage identified by domain
         """

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -151,6 +151,7 @@ class Sync(BrowserView):
                 return self.template()
 
             domain = self.url
+            self.fetch_settings(domain)
             # Fetch all users from the source
             self.fetch_users(domain)
             # Start the fetch process beginning from the portal object
@@ -471,6 +472,28 @@ class Sync(BrowserView):
         remote_portal_id = path.split("/")[1]
         return path.replace(remote_portal_id, portal_id)
 
+    def fetch_settings(self, domain, keys=None):
+        """Fetch source instance settings by keyword
+        """
+        logger.info(" FETCH SETTINGS {} ***".format(domain))
+        storage = self.get_storage(domain=domain)
+        settings_store = storage["settings"]
+
+        if keys is None:
+            retrieved_settings = self.get_settings_by_key()
+        else:
+            retrieved_settings = []
+            for key in keys:
+                retrieved_settings += self.get_settings_by_key(key)
+
+        for setting_dict in retrieved_settings:
+            for key in setting_dict.keys():
+                settings_store[key] = setting_dict[key]
+
+        import pdb; pdb.set_trace()
+
+
+
     def fetch_registry_records(self, domain, keys=None):
         """Fetch configuration registry records of interest (those associated
         to the keywords passed) from source instance
@@ -575,6 +598,14 @@ class Sync(BrowserView):
             return self.get_items("registry")
 
         return self.get_items("registry/{}".format(key))
+
+    def get_settings_by_key(self, key=None):
+        """ Return the settings from the source instance associated
+         to the keyword. If key is None it will return all the settings
+        """
+        if key is None:
+            return self.get_items("settings")
+        return self.get_items("/settings/{}".format(key))
 
     def get_first_item(self, url_or_endpoint, **kw):
         """Fetch the first item of the 'items' list from a std. JSON API reponse
@@ -682,6 +713,7 @@ class Sync(BrowserView):
             self.storage[domain]["uidmap"] = OOBTree()
             self.storage[domain]["credentials"] = OOBTree()
             self.storage[domain]["registry"] = OOBTree()
+            self.storage[domain]["settings"] = OOBTree()
         return self.storage[domain]
 
     def reindex_updated_objects(self):

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -488,6 +488,8 @@ class Sync(BrowserView):
 
         for setting_dict in retrieved_settings:
             for key in setting_dict.keys():
+                if not setting_dict[key]:
+                    continue
                 settings_store[key] = setting_dict[key]
 
     def fetch_registry_records(self, domain, keys=None):

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -28,6 +28,7 @@ class FetchStep(SyncStep):
         logger.info("*** FETCH STARTED {} ***".format(
                                                 self.domain_name))
         self._fetch_registry_records(keys=["bika", "senaite"])
+        self._fetch_settings()
         self._fetch_data()
         logger.info("*** FETCH FINISHED {} ***".format(
                                                 self.domain_name))
@@ -115,6 +116,34 @@ class FetchStep(SyncStep):
             self.domain_name))
 
         transaction.commit()
+
+    def _fetch_settings(self, keys=None):
+        """Fetch source instance settings by keyword
+        """
+        logger.info("*** Fetching Settings: {} ***".format(self.domain_name))
+        storage = self.get_storage()
+        settings_store = storage["settings"]
+
+        if keys is None:
+            retrieved_settings = self._get_settings_by_key()
+        else:
+            retrieved_settings = []
+            for key in keys:
+                retrieved_settings += self._get_settings_by_key(key)
+
+        for setting_dict in retrieved_settings:
+            for key in setting_dict.keys():
+                if not setting_dict[key]:
+                    continue
+                settings_store[key] = setting_dict[key]
+
+    def _get_settings_by_key(self, key=None):
+        """ Return the settings from the source instance associated
+         to the keyword. If key is None it will return all the settings
+        """
+        if key is None:
+            return self.get_items("settings")
+        return self.get_items("/settings/{}".format(key))
 
     def _fetch_registry_records(self, keys=None):
         """Fetch configuration registry records of interest (those associated

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -92,7 +92,9 @@ class ImportStep(SyncStep):
         """Set settings by key
         """
         # Get the Schema interface of the settings being imported
-        ischemas = CONTROLPANEL_INTERFACE_MAPPING[key]
+        ischemas = CONTROLPANEL_INTERFACE_MAPPING.get(key)
+        if not ischemas:
+            return
         for ischema_name in data.keys():
             ischema = None
             for candidate_schema in ischemas:

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -10,10 +10,12 @@ from senaite.jsonapi.fieldmanagers import ProxyFieldManager
 from senaite.sync.syncstep import SyncStep
 
 from zope.component import getUtility
+from zope.component import getAdapter
 from zope.component.interfaces import IFactory
 
 from plone import api as ploneapi
 from plone.registry.interfaces import IRegistry
+import plone.app.controlpanel as cp
 
 from senaite import api
 from senaite.jsonapi.interfaces import IFieldManager
@@ -23,6 +25,29 @@ from senaite.sync.souphandler import SoupHandler
 from senaite.sync import utils
 
 COMMIT_INTERVAL = 1000
+
+CONTROLPANEL_INTERFACE_MAPPING = {
+    'mail': [cp.mail.IMailSchema],
+    'calendar': [cp.calendar.ICalendarSchema],
+    'ram': [cp.ram.IRAMCacheSchema],
+    'language': [cp.language.ILanguageSelectionSchema],
+    'editing': [cp.editing.IEditingSchema],
+    'usergroups': [cp.usergroups.IUserGroupsSettingsSchema,
+                   cp.usergroups.ISecuritySchema, ],
+    'search': [cp.search.ISearchSchema],
+    'filter': [cp.filter.IFilterAttributesSchema,
+               cp.filter.IFilterEditorSchema,
+               cp.filter.IFilterSchema,
+               cp.filter.IFilterTagsSchema],
+    'maintenance': [cp.maintenance.IMaintenanceSchema],
+    'markup': [cp.markup.IMarkupSchema,
+               cp.markup.ITextMarkupSchema,
+               cp.markup.IWikiMarkupSchema, ],
+    'navigation': [cp.navigation.INavigationSchema],
+    'security': [cp.security.ISecuritySchema],
+    'site': [cp.site.ISiteSchema],
+    'skins': [cp.skins.ISkinsSchema],
+}
 
 
 class ImportStep(SyncStep):
@@ -48,9 +73,50 @@ class ImportStep(SyncStep):
         """
         self.session = self.get_session()
         self._import_registry_records()
+        self._import_settings()
         self._import_users()
         self._import_data()
         return
+
+    def _import_settings(self):
+        """Import the settings from the storage identified by domain
+        """
+        logger.info("*** Importing Settings: {} ***".format(self.domain_name))
+
+        storage = self.get_storage()
+        settings_store = storage["settings"]
+        for key in settings_store:
+            self._set_settings(key, settings_store[key])
+
+    def _set_settings(self, key, data):
+        """Set settings by key
+        """
+        # Get the Schema interface of the settings being imported
+        ischemas = CONTROLPANEL_INTERFACE_MAPPING[key]
+        for ischema_name in data.keys():
+            ischema = None
+            for candidate_schema in ischemas:
+                if candidate_schema.getName() == ischema_name:
+                    ischema = candidate_schema
+            schema = getAdapter(api.get_portal(), ischema)
+            # Once we have the schema set the data
+            schema_import_data = data.get(ischema_name)
+            for schema_field in schema_import_data:
+                if schema_import_data[schema_field]:
+                    self._set_attr_from_json(schema, schema_field, schema_import_data[schema_field])
+
+    def _set_attr_from_json(self, schema, attribute, data):
+        """Set schema attribute from JSON data. Since JSON converts tuples to lists
+           we have to perform a preventive check before setting the value to see if the
+           expected value is a tuple or a list. In the case it is a tuple we cast the list
+           to tuple
+        """
+        if hasattr(schema, attribute) and data:
+            current_value = getattr(schema, attribute)
+            if type(current_value) == tuple:
+                setattr(schema, attribute, tuple(data))
+            else:
+                setattr(schema, attribute, data)
 
     def _import_registry_records(self):
         """Import the registry records from the storage identified by domain

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -140,7 +140,6 @@ class SyncStep:
             self.storage[domain] = OOBTree()
             self.storage[domain]["credentials"] = OOBTree()
             self.storage[domain]["registry"] = OOBTree()
-            self.storage[domain]["settings"] = OOBTree()
             self.storage[domain]["ordered_uids"] = []
         return self.storage[domain]
 

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -140,6 +140,7 @@ class SyncStep:
             self.storage[domain] = OOBTree()
             self.storage[domain]["credentials"] = OOBTree()
             self.storage[domain]["registry"] = OOBTree()
+            self.storage[domain]["settings"] = OOBTree()
             self.storage[domain]["ordered_uids"] = []
         return self.storage[domain]
 


### PR DESCRIPTION
Superseeds: #10 
Related PR: https://github.com/senaite/senaite.jsonapi/pull/14

## Description of the issue/feature this PR addresses

Add functionality for fetching and importing/syncing general settings between two instances.

Currently the availabe settings that can be queried are those that are defined under `plone.app.controlpanel` and implement an interface in the form of `ISomethingSchema`. The returned settings will be those associated to the schema `ISomethingSchema` With these restrictions the supported keywords are:
1. mail
2. calendar
3. ram
4. language
5. editing
6. usergroups
7. search
8. filter
9. maintenance
10. markup
11. naviagtion
12. security
13. site
14. skins

## Current behavior before PR

Settings were not being imported/synced

## Desired behavior after PR is merged

Settings can be fetched and imported/synced properly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html