### PR TITLE
Implement upgrade step machinery

### DIFF
--- a/src/senaite/sync/config.py
+++ b/src/senaite/sync/config.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.LIMS
+#
+# Copyright 2018 by it's authors.
+# Some rights reserved. See LICENSE and CONTRIBUTING.
+
+PROJECTNAME = "senaite.sync"

--- a/src/senaite/sync/configure.zcml
+++ b/src/senaite/sync/configure.zcml
@@ -1,12 +1,22 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:five="http://namespaces.zope.org/five"
-    i18n_domain="senaite">
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    i18n_domain="senaite.sync">
 
   <five:registerPackage package="." initialize=".initialize"/>
 
   <!-- include packages -->
   <include package=".browser" />
+  <include package=".upgrade"/>
+
+  <!-- Installation Profile -->
+  <genericsetup:registerProfile
+      name="default"
+      title="SENAITE SYNC"
+      directory="profiles/default"
+      description="SENAITE SYNC Extension Profile"
+      provides="Products.GenericSetup.interfaces.EXTENSION"/>
 
   <!-- AT FIELD MANAGERS
        Field level interface to get and set values and get a JSON compatible

--- a/src/senaite/sync/profiles/default/metadata.xml
+++ b/src/senaite/sync/profiles/default/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<metadata>
+  <version>1.0.0</version>
+  <dependencies>
+      <dependency>profile-senaite.sync:default</dependency>
+  </dependencies>
+</metadata>

--- a/src/senaite/sync/upgrade/__init__.py
+++ b/src/senaite/sync/upgrade/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.SYNC
+#
+# Copyright 2018 by it's authors.
+# Some rights reserved. See LICENSE.rst.

--- a/src/senaite/sync/upgrade/configure.zcml
+++ b/src/senaite/sync/upgrade/configure.zcml
@@ -1,0 +1,13 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    i18n_domain="senaite.sync">
+
+ <genericsetup:upgradeStep
+        title="Upgrade to SENAITE Sync 1.0.0"
+        source="1000"
+        destination="1.0.0"
+        handler="senaite.sync.upgrade.v01_00_000.upgrade"
+        profile="senaite.sync:default"/>
+
+</configure>

--- a/src/senaite/sync/upgrade/v01_00_000.py
+++ b/src/senaite/sync/upgrade/v01_00_000.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.SYNC
+#
+# Copyright 2018 by it's authors.
+
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+
+from bika.lims.upgrade import upgradestep
+
+version = '1.0.0'
+profile = 'profile-{senaite.sync}:default'
+
+
+@upgradestep('senaite.sync', version)
+def upgrade(tool):
+    portal = aq_parent(aq_inner(tool))
+    return True

--- a/src/senaite/sync/upgrade/v01_00_000.py
+++ b/src/senaite/sync/upgrade/v01_00_000.py
@@ -6,6 +6,7 @@
 
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from zope.annotation.interfaces import IAnnotations
 
 from bika.lims.upgrade import upgradestep
 
@@ -16,4 +17,7 @@ profile = 'profile-{senaite.sync}:default'
 @upgradestep('senaite.sync', version)
 def upgrade(tool):
     portal = aq_parent(aq_inner(tool))
+    annotation = IAnnotations(portal)
+    if annotation.get("senaite.sync") is not None:
+        del annotation["senaite.sync"]
     return True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR implements the upgrade step machinery for `senaite.sync` with the main aim of achieving backwards compatibility. It is based on https://github.com/senaite/senaite.lims/pull/26/commits/db5c1cf7094200304e95da2981a413e6704e5ad1

**Note**: Review the PR carefully because I haven't worked that much with the upgrade step machinery and I may be missing or adding extra things apart from the upgrade step machinery. 

## Current behavior before PR

It wasn't possible to develop upgrade steps for `senaite.sync`.

## Desired behavior after PR is merged

Upgrade steps can be developed for `senaite.sync`.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html