### PR TITLE
Log the status of the import process.

### DIFF
--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -113,6 +113,7 @@ class ImportStep(SyncStep):
         self.uids_to_reindex = []
         storage = self.get_storage()
         ordered_uids = storage["ordered_uids"]
+        total_object_count = len(ordered_uids)
         
         for item_count, r_uid in enumerate(ordered_uids):
             row = self.sh.find_unique("remote_uid", r_uid)
@@ -131,9 +132,9 @@ class ImportStep(SyncStep):
             if self._non_commited_objects > COMMIT_INTERVAL:
                 transaction.commit()
                 logger.info("Committed: {} / {} ".format(
-                            self._non_commited_objects, len(ordered_uids)))
+                            self._non_commited_objects, total_object_count))
                 self._non_commited_objects = 0
-            logger.info("Imported: {} / {}".format(item_count+1, len(ordered_uids)))
+            logger.info("Imported: {} / {}".format(item_count+1, total_object_count))
         # Delete the UID list from the storage.
         storage["ordered_uids"] = []
         # Mark all objects as non-updated for the next import.

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -114,7 +114,7 @@ class ImportStep(SyncStep):
         storage = self.get_storage()
         ordered_uids = storage["ordered_uids"]
         total_object_count = len(ordered_uids)
-        
+
         for item_count, r_uid in enumerate(ordered_uids):
             row = self.sh.find_unique("remote_uid", r_uid)
             logger.info("Handling: {} ".format(row["path"]))

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -113,6 +113,7 @@ class ImportStep(SyncStep):
         self.uids_to_reindex = []
         storage = self.get_storage()
         ordered_uids = storage["ordered_uids"]
+        
         for item_count, r_uid in enumerate(ordered_uids):
             row = self.sh.find_unique("remote_uid", r_uid)
             logger.info("Handling: {} ".format(row["path"]))

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -113,8 +113,7 @@ class ImportStep(SyncStep):
         self.uids_to_reindex = []
         storage = self.get_storage()
         ordered_uids = storage["ordered_uids"]
-
-        for r_uid in ordered_uids:
+        for item_count, r_uid in enumerate(ordered_uids):
             row = self.sh.find_unique("remote_uid", r_uid)
             logger.info("Handling: {} ".format(row["path"]))
             self._handle_obj(row)
@@ -133,7 +132,7 @@ class ImportStep(SyncStep):
                 logger.info("Committed: {} / {} ".format(
                             self._non_commited_objects, len(ordered_uids)))
                 self._non_commited_objects = 0
-
+            logger.info("Imported: {} / {}".format(item_count+1, len(ordered_uids)))
         # Delete the UID list from the storage.
         storage["ordered_uids"] = []
         # Mark all objects as non-updated for the next import.


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When importing data from another instance the user cannot know how many objects have been imported out from the total amount to be imported.

## Current behavior before PR

No info is logged that informs the user on which is the the current status of the import process (How many objects out of the total number of objects have been imported).

## Desired behavior after PR is merged

The current status of the import process is logged into the terminal. This is done by showing the number of objects already imported out of the total number of objects to be imported.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008

