### PR TITLE
Content Type Filtering for Migration.

### DIFF
--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -122,6 +122,28 @@
           </div>
         </div>
 
+        <!-- Content Types -->
+        <div class="field form-group field">
+          <label i18n:translate=""
+                 class="form-control-label"
+                 for="content_types">
+            Content Types
+            <span i18n:translate=""
+                  class="help formHelp">
+              If filled, only indicated Content Types (separated by comma) will be imported. E.g: 'Sample, Client, Worksheet'
+            </span>
+          </label>
+          <div class="form-group input-group">
+            <span class="input-group-addon"><i class="glyphicon glyphicon-lock"></i></span>
+            <input type="text"
+                   size="45"
+                   class="form-control"
+                   id="content_types"
+                   tal:attributes="value view/content_types|nothing"
+                   name="content_types"/>
+          </div>
+        </div>
+
         <input class="btn btn-success btn-sm allowMultiSubmit"
                type="submit"
                name="fetch"

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -60,15 +60,17 @@ class Sync(BrowserView):
         if form.get("import", False):
             domain_name = form.get("domain_name", None)
             # initialize the session
-            storage = self.get_storage(self.domain_name)
+            storage = self.get_storage(domain_name)
             url = storage["credentials"]["url"]
             username = storage["credentials"]["username"]
             password = storage["credentials"]["password"]
+            content_types = storage["credentials"]["content_types"]
             data = {
                 "url": url,
                 "domain_name": domain_name,
                 "ac_name": username,
                 "ac_password": password,
+                "content_types": content_types,
             }
             step = ImportStep(data)
             step.run()

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -101,7 +101,7 @@ class Sync(BrowserView):
 
             ct = form.get("content_types", None)
             if ct:
-                content_types = [t.title() for t in ct.split(",") if t]
+                content_types = [t for t in ct.split(",") if t]
             else:
                 content_types = None
             data = {

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -64,7 +64,7 @@ class Sync(BrowserView):
             url = storage["credentials"]["url"]
             username = storage["credentials"]["username"]
             password = storage["credentials"]["password"]
-            content_types = storage["credentials"]["content_types"]
+            content_types = storage["content_types"]
             data = {
                 "url": url,
                 "domain_name": domain_name,
@@ -145,6 +145,7 @@ class Sync(BrowserView):
             self.storage[domain]["credentials"] = OOBTree()
             self.storage[domain]["registry"] = OOBTree()
             self.storage[domain]["ordered_uids"] = []
+            self.storage[domain]["content_types"] = []
         return self.storage[domain]
 
     @property

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -103,7 +103,7 @@ class Sync(BrowserView):
 
             ct = form.get("content_types", None)
             if ct:
-                content_types = [t for t in ct.split(",") if t]
+                content_types = [t.strip() for t in ct.split(",") if t]
             else:
                 content_types = None
             data = {

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -101,11 +101,10 @@ class Sync(BrowserView):
                 self.add_status_message(message, "error")
                 return self.template()
 
-            ct = form.get("content_types", None)
-            if ct:
-                content_types = [t.strip() for t in ct.split(",") if t]
-            else:
-                content_types = None
+            content_types = form.get("content_types", None)
+            if content_types is not None:
+                content_types = [t.strip() for t in content_types.split(",")
+                                 if t]
             data = {
                 "url": url,
                 "domain_name": domain_name,

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -56,15 +56,6 @@ class Sync(BrowserView):
         if not any([fetchform, dataform]):
             return self.template()
 
-        # remember the form field values
-        url = form.get("url", "")
-        if not url.startswith("http"):
-            url = "http://{}".format(url)
-        self.url = url
-        self.domain_name = form.get("domain_name", None)
-        self.username = form.get("ac_name", None)
-        self.password = form.get("ac_password", None)
-
         # Handle "Import" action
         if form.get("import", False):
             domain_name = form.get("domain_name", None)
@@ -94,18 +85,31 @@ class Sync(BrowserView):
 
         # Handle "Fetch" action
         if form.get("fetch", False):
+
+            url = form.get("url", "")
+            if not url.startswith("http"):
+                url = "http://{}".format(url)
+            domain_name = form.get("domain_name", None)
+            username = form.get("ac_name", None)
+            password = form.get("ac_password", None)
             # check if all mandatory fields have values
-            if not all([self.domain_name, self.url, self.username,
-                        self.password]):
+            if not all([domain_name, url, username,
+                        password]):
                 message = _("Please fill in all required fields")
                 self.add_status_message(message, "error")
                 return self.template()
 
+            ct = form.get("content_types", None)
+            if ct:
+                content_types = [t.title() for t in ct.split(",") if t]
+            else:
+                content_types = None
             data = {
-                "url": form.get("url", None),
-                "domain_name": form.get("domain_name", None),
-                "ac_name": form.get("ac_name", None),
-                "ac_password": form.get("ac_password", None),
+                "url": url,
+                "domain_name": domain_name,
+                "ac_name": username,
+                "ac_password": password,
+                "content_types": content_types,
             }
 
             fs = FetchStep(data)

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -64,7 +64,7 @@ class Sync(BrowserView):
             url = storage["credentials"]["url"]
             username = storage["credentials"]["username"]
             password = storage["credentials"]["password"]
-            content_types = storage["content_types"]
+            content_types = storage["configuration"].get("content_types", None)
             data = {
                 "url": url,
                 "domain_name": domain_name,
@@ -149,7 +149,7 @@ class Sync(BrowserView):
             self.storage[domain]["credentials"] = OOBTree()
             self.storage[domain]["registry"] = OOBTree()
             self.storage[domain]["ordered_uids"] = []
-            self.storage[domain]["content_types"] = []
+            self.storage[domain]["configuration"] = OOBTree()
         return self.storage[domain]
 
     @property

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -105,6 +105,10 @@ class Sync(BrowserView):
             if content_types is not None:
                 content_types = [t.strip() for t in content_types.split(",")
                                  if t]
+                portal_types = api.get_tool("portal_types")
+                content_types = filter(lambda ct: ct in portal_types,
+                                       content_types)
+
             data = {
                 "url": url,
                 "domain_name": domain_name,

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -21,10 +21,6 @@ class FetchStep(SyncStep):
     Fetch step of data migration.
     """
 
-    def __init__(self, data):
-        SyncStep.__init__(self, data)
-        self.content_types = data.get("content_types", None)
-
     def run(self):
         """
         :return:
@@ -60,6 +56,7 @@ class FetchStep(SyncStep):
         storage["credentials"]["url"] = self.url
         storage["credentials"]["username"] = self.username
         storage["credentials"]["password"] = self.password
+        storage["credentials"]["content_types"] = self.content_types
         message = "Fetching Data started for {}".format(self.domain_name)
         return True, message
 

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -159,4 +159,4 @@ class FetchStep(SyncStep):
         if key is None:
             return self.get_items("registry")
 
-        return self.get_items("registry/{}".format(key))
+        return self.get_items("/".join(["registry", key]))

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -56,7 +56,7 @@ class FetchStep(SyncStep):
         storage["credentials"]["url"] = self.url
         storage["credentials"]["username"] = self.username
         storage["credentials"]["password"] = self.password
-        storage["credentials"]["content_types"] = self.content_types
+        storage["content_types"] = self.content_types
         message = "Fetching Data started for {}".format(self.domain_name)
         return True, message
 

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -111,8 +111,8 @@ class FetchStep(SyncStep):
             for item in items:
                 # skip object or extract the required data for the import
                 if item.get("portal_type", "SKIP") in SKIP_PORTAL_TYPES:
-                    logger.info("Skipping unnecessary portal type: {}"
-                                .format(item))
+                    logger.debug("Skipping unnecessary portal type: {}"
+                                 .format(item))
                     continue
                 data_dict = utils.get_soup_format(item)
                 rec_id = self.sh.insert(data_dict)

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -160,27 +160,3 @@ class FetchStep(SyncStep):
             return self.get_items("registry")
 
         return self.get_items("registry/{}".format(key))
-
-    def _fetch_missing_parents(self, item):
-        """
-        If data was fetched with portal type filter, this method will be used
-        to fill the missing parents for fetched objects.
-        :return:
-        """
-        if not self.content_types:
-            return
-
-        parent_path = item.get("parent_path")
-        # Skip if the parent is portal object
-        if len(parent_path.split("/")) < 3:
-            return
-        # Skip if already exists
-        if self.sh.find_unique("path", parent_path):
-            return
-
-        logger.info("Inserting missing parent: {}".format(parent_path))
-        parent = self.get_first_item(item.get("parent_url"))
-        par_dict = utils.get_soup_format(parent)
-        self.sh.insert(par_dict)
-        # Recursively import grand parents too
-        self._fetch_missing_parents(parent)

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -56,7 +56,7 @@ class FetchStep(SyncStep):
         storage["credentials"]["url"] = self.url
         storage["credentials"]["username"] = self.username
         storage["credentials"]["password"] = self.password
-        storage["content_types"] = self.content_types
+        storage["configuration"]["content_types"] = self.content_types
         message = "Fetching Data started for {}".format(self.domain_name)
         return True, message
 

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -103,7 +103,7 @@ class FetchStep(SyncStep):
         for current_page in xrange(number_of_pages):
             start_from = (current_page * window) - overlap
             query["limit"] = window
-            query["b_from"] = start_from
+            query["b_start"] = start_from
             items = self.get_items(**query)
             if not items:
                 logger.error("CAN NOT GET ITEMS FROM {} TO {}".format(

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -86,11 +86,11 @@ class ImportStep(SyncStep):
         for user in self.yield_items("users"):
             username = user.get("username")
             if ploneapi.user.get(username):
-                logger.info("Skipping existing user {}".format(username))
+                logger.debug("Skipping existing user {}".format(username))
                 continue
             email = user.get("email", "")
             roles = user.get("roles", ())
-            logger.info("Creating user {}".format(username))
+            logger.debug("Creating user {}".format(username))
             message = _("Created new user {} with password {}".format(
                         username, username))
             # create new user with the same password as the username

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -67,7 +67,7 @@ class ImportStep(SyncStep):
         for key in registry_store.keys():
             records = registry_store[key]
             for record in records.keys():
-                logger.info("Updating record {} with value {}".format(
+                logger.debug("Updating record {} with value {}".format(
                             record, records.get(record)))
                 if record not in current_registry.records:
                     logger.warn("Current Registry has no record named {}"
@@ -98,7 +98,7 @@ class ImportStep(SyncStep):
                                  username=username,
                                  password=username,
                                  roles=roles,)
-            logger.info(message)
+            logger.debug(message)
 
         logger.info("*** Users Were Imported: {} ***".format(self.domain_name))
 
@@ -117,7 +117,7 @@ class ImportStep(SyncStep):
 
         for r_uid in ordered_uids:
             row = self.sh.find_unique("remote_uid", r_uid)
-            logger.info("Handling: {} ".format(row["path"]))
+            logger.debug("Handling: {} ".format(row["path"]))
             self._handle_obj(row)
 
             # Handling object means there is a chunk containing several objects
@@ -139,8 +139,8 @@ class ImportStep(SyncStep):
             # Commit the transaction if necessary
             if self._non_commited_objects > COMMIT_INTERVAL:
                 transaction.commit()
-                logger.info("Committed: {} / {} ".format(
-                            self._non_commited_objects, len(ordered_uids)))
+                logger.info("Committing {} objects."
+                            .format(self._non_commited_objects))
                 self._non_commited_objects = 0
 
         # Delete the UID list from the storage.
@@ -180,7 +180,7 @@ class ImportStep(SyncStep):
             self._queue.remove(r_uid)
         except Exception, e:
             self._queue.remove(r_uid)
-            logger.error('Failed to handle: {} \n {} '.format(row, str(e)))
+            logger.error('Failed to handle {} : {} '.format(row, str(e)))
 
         return True
 
@@ -291,7 +291,7 @@ class ImportStep(SyncStep):
                             if 'uid' in k:
                                 dependencies.append(v)
 
-        logger.info("Dependencies of {} are : {} ".format(repr(obj),
+        logger.debug("Dependencies of {} are : {} ".format(repr(obj),
                                                           dependencies))
         dependencies = list(set(dependencies))
         for r_uid in dependencies:
@@ -382,7 +382,7 @@ class ImportStep(SyncStep):
             try:
                 fm.set(obj, value)
             except:
-                logger.warn(
+                logger.debug(
                     "Could not set field '{}' with value '{}'".format(
                         fieldname, value))
 
@@ -394,7 +394,7 @@ class ImportStep(SyncStep):
             try:
                 fm.set(obj, value)
             except:
-                logger.warn(
+                logger.debug(
                     "Could not set field '{}' with value '{}'".format(
                         field_name,
                         value))
@@ -419,7 +419,7 @@ class ImportStep(SyncStep):
         if not fti:
             logger.error("Type Info not found for {}".format(portal_type))
             return None
-        logger.info("Creating {} with ID {} in parent path {}".format(
+        logger.debug("Creating {} with ID {} in parent path {}".format(
             portal_type, id, api.get_path(container)))
 
         if fti.product:
@@ -455,7 +455,7 @@ class ImportStep(SyncStep):
             if wf_id == wf_def.getId():
                 break
         else:
-            logger.error("%s: Cannot find workflow id %s" % (content, wf_id))
+            logger.warn("%s: Cannot find workflow id %s" % (content, wf_id))
 
         for rh in sorted(review_history, key=lambda k: k['time']):
             if not utils.review_history_imported(content, rh, wf_def):

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -7,6 +7,7 @@ import transaction
 
 from Products.CMFPlone.utils import _createObjectByType
 from senaite.jsonapi.fieldmanagers import ProxyFieldManager
+from senaite.jsonapi.fieldmanagers import ComputedFieldManager
 from senaite.sync.syncstep import SyncStep
 
 from zope.component import getUtility
@@ -337,6 +338,10 @@ class ImportStep(SyncStep):
 
             fm = IFieldManager(field)
             value = data.get(fieldname)
+
+            # Computed Fields don't have set methods.
+            if isinstance(fm, ComputedFieldManager):
+                continue
 
             # handle JSON data reference fields
             if isinstance(value, dict) and value.get("uid"):

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -222,26 +222,23 @@ class ImportStep(SyncStep):
 
         # Check if the parent already exists. If yes, make sure it has
         # 'local_uid' value set in the soup table.
-        try:
-            existing = self.portal.unrestrictedTraverse(str(local_path), None)
-            if existing:
-                # Skip if its the portal object.
-                if len(p_path.split("/")) < 3:
-                    return
-                p_row = self.sh.find_unique("path", p_path)
-                if p_row is None:
-                    return
-                p_local_uid = self.sh.find_unique("path", p_path).get(
-                                                        "local_uid", None)
-                if not p_local_uid:
-                    if hasattr(existing, "UID") and existing.UID():
-                        p_local_uid = existing.UID()
-                        self.sh.update_by_path(p_path, local_uid=p_local_uid)
+
+        existing = self.portal.unrestrictedTraverse(str(local_path), None)
+        if existing:
+            # Skip if its the portal object.
+            if len(p_path.split("/")) < 3:
                 return
-        except TypeError, e:
-            logger.warn("ERROR WHILE ACCESSING AN EXISTING OBJECT: {} "
-                        .format(str(e)))
+            p_row = self.sh.find_unique("path", p_path)
+            if p_row is None:
+                return
+            p_local_uid = self.sh.find_unique("path", p_path).get(
+                                                    "local_uid", None)
+            if not p_local_uid:
+                if hasattr(existing, "UID") and existing.UID():
+                    p_local_uid = existing.UID()
+                    self.sh.update_by_path(p_path, local_uid=p_local_uid)
             return
+
         # Before creating an object's parent, make sure grand parents are
         # already ready.
         self._create_parents(p_path)

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -340,7 +340,10 @@ class ImportStep(SyncStep):
             if isinstance(value, dict) and value.get("uid"):
                 # dereference the referenced object
                 local_uid = self.sh.get_local_uid(value.get("uid"))
-                value = api.get_object_by_uid(local_uid)
+                if local_uid:
+                    value = api.get_object_by_uid(local_uid)
+                else:
+                    value = None
 
             elif isinstance(value, (list, tuple)):
                 for item in value:

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -387,8 +387,6 @@ class ImportStep(SyncStep):
             field_name = pf.get("field_name")
             fm = pf.get("fm")
             value = pf.get("value")
-            logger.info("Setting value={} on field={} of object={}".format(
-                repr(value), field_name, api.get_id(obj)))
             try:
                 fm.set(obj, value)
             except:

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -370,9 +370,6 @@ class ImportStep(SyncStep):
                 proxy_fields.append({'field_name': fieldname,
                                      'fm': fm, 'value': value})
                 continue
-
-            logger.info("Setting value={} on field={} of object={}".format(
-                repr(value), fieldname, api.get_id(obj)))
             try:
                 fm.set(obj, value)
             except:

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -124,7 +124,15 @@ class ImportStep(SyncStep):
             # which have been created and updated. Reindex them now.
             self.uids_to_reindex = list(set(self.uids_to_reindex))
             for uid in self.uids_to_reindex:
-                api.get_object_by_uid(uid).reindexObject()
+                # It is possible that the object has a method (not a Field
+                # in its Schema) which is used as an index and it fails.
+                # TODO: Make sure reindexing won't fail!
+                try:
+                    api.get_object_by_uid(uid).reindexObject()
+                except Exception, e:
+                    rec = self.sh.find_unique("local_uid", uid)
+                    logger.error("Error while reindexing {} - {}"
+                                 .format(rec, e))
             self._non_commited_objects += len(self.uids_to_reindex)
             self.uids_to_reindex = []
 

--- a/src/senaite/sync/souphandler.py
+++ b/src/senaite/sync/souphandler.py
@@ -53,7 +53,7 @@ class SoupHandler:
         :return: intid of created record
         """
         if self._already_exists(data):
-            logger.info("Trying to insert existing record... {}".format(data))
+            logger.debug("Trying to insert existing record... {}".format(data))
             return False
         record = Record()
         record.attrs['remote_uid'] = data['remote_uid']

--- a/src/senaite/sync/souphandler.py
+++ b/src/senaite/sync/souphandler.py
@@ -99,7 +99,6 @@ class SoupHandler:
         recs = [r for r in self.soup.query(Eq(column, value))]
         if recs:
             return record_to_dict(recs[0])
-        logger.error("NOT FOUND ANY RECORD: {} - {} ".format(column, value))
         return None
 
     def get_local_uid(self, r_uid):

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -77,7 +77,7 @@ class SyncStep:
         """Fetch the given url or endpoint and return a parsed JSON object
         """
         api_url = self.get_api_url(url_or_endpoint, **kw)
-        logger.info("get_json::url={}".format(api_url))
+        logger.debug("get_json::url={}".format(api_url))
         try:
             response = self.session.get(api_url)
         except Exception as e:
@@ -176,7 +176,7 @@ class SyncStep:
         # Skip if already exists
         if self.sh.find_unique("path", parent_path):
             return
-        logger.info("Inserting missing parent: {}".format(parent_path))
+        logger.debug("Inserting missing parent: {}".format(parent_path))
         parent = self.get_first_item(item.get("parent_url"))
         par_dict = utils.get_soup_format(parent)
         self.sh.insert(par_dict)

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -10,6 +10,7 @@ from BTrees.OOBTree import OOBTree
 from zope.annotation.interfaces import IAnnotations
 from senaite import api
 from senaite.sync import logger
+from senaite.sync import utils
 from senaite.sync.syncerror import SyncError
 
 SYNC_STORAGE = "senaite.sync"
@@ -161,3 +162,23 @@ class SyncStep:
         annotation = self.get_annotation()
         if annotation.get(SYNC_STORAGE) is not None:
             del annotation[SYNC_STORAGE]
+
+    def _fetch_missing_parents(self, item):
+        """
+        If data was fetched with portal type filter, this method will be used
+        to fill the missing parents for fetched objects.
+        :return:
+        """
+        parent_path = item.get("parent_path")
+        # Skip if the parent is portal object
+        if len(parent_path.split("/")) < 3:
+            return
+        # Skip if already exists
+        if self.sh.find_unique("path", parent_path):
+            return
+        logger.info("Inserting missing parent: {}".format(parent_path))
+        parent = self.get_first_item(item.get("parent_url"))
+        par_dict = utils.get_soup_format(parent)
+        self.sh.insert(par_dict)
+        # Recursively import grand parents too
+        self._fetch_missing_parents(parent)

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -143,7 +143,7 @@ class SyncStep:
             self.storage[domain]["credentials"] = OOBTree()
             self.storage[domain]["registry"] = OOBTree()
             self.storage[domain]["ordered_uids"] = []
-            self.storage[domain]["content_types"] = []
+            self.storage[domain]["configuration"] = OOBTree()
         return self.storage[domain]
 
     @property

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -143,6 +143,7 @@ class SyncStep:
             self.storage[domain]["credentials"] = OOBTree()
             self.storage[domain]["registry"] = OOBTree()
             self.storage[domain]["ordered_uids"] = []
+            self.storage[domain]["content_types"] = []
         return self.storage[domain]
 
     @property

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -32,6 +32,7 @@ class SyncStep:
         self.domain_name = data.get("domain_name", None)
         self.username = data.get("ac_name", None)
         self.password = data.get("ac_password", None)
+        self.content_types = data.get("content_types", None)
 
         if not any([self.domain_name, self.url, self.username, self.password]):
             self.fail("Missing parameter in Sync Step: {}".format(data))


### PR DESCRIPTION
**Current Behavior**
While fetching data, it is not possible to filter the objects from the source instance. It would be nice if users could choose content types they want to import into the destination.

**Expected Behavior after this PR**
Users can enter content types separated by comma ( , ) to filter the objects that will be imported.
_________________________________________________

It is possible that `sync`  will have to create some 'unwanted' objects if they are dependencies of main objects. However, for that kind of objects, dependencies will not be created recursively. It might cause an error during 'reindexing' those objects. A `try:except` added especially for that case.

Also some log levels and messages were updated to avoid noise in the logs and make them more understandable.