### PR TITLE
Configurable import

### DIFF
--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -137,8 +137,7 @@
                     <div>
                       <input type="checkbox"
                              name="import_settings"
-                             id="import_settings"
-	   	                     tal:attributes="checked view/import_settings"/>
+                             id="import_settings"/>
 	     	          <label for="import_settings">Import Settings</label>
 	                </div>
                   </li>
@@ -146,8 +145,7 @@
                     <div>
                       <input type="checkbox"
                              name="import_registry"
-                             id="import_registry"
-	   	                     tal:attributes="checked view/import_registry"/>
+                             id="import_registry"/>
 	     	          <label for="import_settings">Import Registry</label>
 	                </div>
                   </li>
@@ -155,8 +153,7 @@
                     <div>
                       <input type="checkbox"
                              name="import_users"
-                             id="import_users"
-	   	                     tal:attributes="checked view/import_users"/>
+                             id="import_users"/>
 	     	          <label for="import_settings">Import Users</label>
 	                </div>
                   </li>

--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -185,6 +185,7 @@
               </ul>
             </div>
           </div>
+        </div>
 
         <input class="btn btn-success btn-sm allowMultiSubmit"
                type="submit"

--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -164,11 +164,32 @@
 	     	          <label for="import_settings">Import Users</label>
 	                </div>
                   </li>
-                </ul>
-              </div>
+                  <li class="list-group-item">
+                    <!-- Content Types -->
+                    <div class="field form-group field">
+                      <label i18n:translate=""
+                             class="form-control-label"
+                             for="content_types">
+                        Content Types
+                        <span i18n:translate=""
+                              class="help formHelp">
+                          If filled, only indicated Content Types (separated by comma) will be imported. E.g: 'Sample, Client, Worksheet'
+                        </span>
+                      </label>
+                      <div class="form-group input-group">
+                        <span class="input-group-addon"><i class="glyphicon glyphicon-lock"></i></span>
+                        <input type="text"
+                               size="45"
+                               class="form-control"
+                               id="content_types"
+                               tal:attributes="value view/content_types|nothing"
+                               name="content_types"/>
+                      </div>
+                    </div>
+                </li>
+              </ul>
             </div>
           </div>
-        </div>
 
         <input class="btn btn-success btn-sm allowMultiSubmit"
                type="submit"

--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -173,7 +173,6 @@
                         </span>
                       </label>
                       <div class="form-group input-group">
-                        <span class="input-group-addon"><i class="glyphicon glyphicon-lock"></i></span>
                         <input type="text"
                                size="45"
                                class="form-control"

--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -122,6 +122,54 @@
           </div>
         </div>
 
+        <!-- Import configuration -->
+        <div class="field form-group field">
+          <label i18n:translate=""
+                 class="form-control-label">
+            Import configuration
+          </label>
+          <div class="panel-group">
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <h4 class="panel-title">
+                 <a data-toggle="collapse" href="#collapse1">Show import configuration</a>
+               </h4>
+              </div>
+              <div id="collapse1" class="panel-collapse collapse">
+                <ul class="list-group">
+                  <li class="list-group-item">
+                    <div>
+                      <input type="checkbox"
+                             name="import_settings"
+                             id="import_settings"
+	   	                     tal:attributes="checked view/import_settings"/>
+	     	          <label for="import_settings">Import Settings</label>
+	                </div>
+                  </li>
+                  <li class="list-group-item">
+                    <div>
+                      <input type="checkbox"
+                             name="import_registry"
+                             id="import_registry"
+	   	                     tal:attributes="checked view/import_registry"/>
+	     	          <label for="import_settings">Import Registry</label>
+	                </div>
+                  </li>
+                  <li class="list-group-item">
+                    <div>
+                      <input type="checkbox"
+                             name="import_users"
+                             id="import_users"
+	   	                     tal:attributes="checked view/import_users"/>
+	     	          <label for="import_settings">Import Users</label>
+	                </div>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <input class="btn btn-success btn-sm allowMultiSubmit"
                type="submit"
                name="fetch"

--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -205,6 +205,12 @@
               (<span tal:replace="python:len(view.storage[storage]['ordered_uids'])"/> Items)
             </dt>
 
+            <dl class="collapsible">
+              Import settings: <span tal:replace="python:view.storage[storage]['configuration'].get('import_settings')"/>,
+              Import registry: <span tal:replace="python:view.storage[storage]['configuration'].get('import_registry')"/>,
+              Import users: <span tal:replace="python:view.storage[storage]['configuration'].get('import_users')"/>
+            </dl>
+
             <input type="hidden" name="dataform" value="1"/>
             <input type="hidden" name="domain_name" value="" tal:attributes="value storage" />
 

--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -124,10 +124,6 @@
 
         <!-- Import configuration -->
         <div class="field form-group field">
-          <label i18n:translate=""
-                 class="form-control-label">
-            Import configuration
-          </label>
           <div class="panel-group">
             <div class="panel panel-default">
               <div class="panel-heading">

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -104,11 +104,18 @@ class Sync(BrowserView):
                 self.add_status_message(message, "error")
                 return self.template()
 
+            import_settings = True if form.get("import_settings") == 'on' else False
+            import_users = True if form.get("import_users") == 'on' else False
+            import_registry = True if form.get("import_registry") == 'on' else False
+
             data = {
                 "url": form.get("url", None),
                 "domain_name": form.get("domain_name", None),
                 "ac_name": form.get("ac_name", None),
                 "ac_password": form.get("ac_password", None),
+                "import_settings": import_settings,
+                "import_users": import_users,
+                "import_registry": import_registry,
             }
 
             fs = FetchStep(data)
@@ -144,6 +151,7 @@ class Sync(BrowserView):
             self.storage[domain]["registry"] = OOBTree()
             self.storage[domain]["settings"] = OOBTree()
             self.storage[domain]["ordered_uids"] = []
+            self.storage[domain]["configuration"] = OOBTree()
         return self.storage[domain]
 
     @property

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -41,9 +41,6 @@ class Sync(BrowserView):
         self.username = None
         self.password = None
         self.session = None
-        self.import_settings = False
-        self.import_registry = False
-        self.import_users = False
 
     def __call__(self):
         protect.CheckAuthenticator(self.request.form)

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -41,6 +41,9 @@ class Sync(BrowserView):
         self.username = None
         self.password = None
         self.session = None
+        self.import_settings = False
+        self.import_registry = False
+        self.import_users = False
 
     def __call__(self):
         protect.CheckAuthenticator(self.request.form)

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -27,8 +27,10 @@ class FetchStep(SyncStep):
         """
         logger.info("*** FETCH STARTED {} ***".format(
                                                 self.domain_name))
-        self._fetch_registry_records(keys=["bika", "senaite"])
-        self._fetch_settings()
+        if self.import_registry:
+            self._fetch_registry_records(keys=["bika", "senaite"])
+        if self.import_settings:
+            self._fetch_settings()
         self._fetch_data()
         logger.info("*** FETCH FINISHED {} ***".format(
                                                 self.domain_name))
@@ -57,6 +59,11 @@ class FetchStep(SyncStep):
         storage["credentials"]["url"] = self.url
         storage["credentials"]["username"] = self.username
         storage["credentials"]["password"] = self.password
+        # remember import configuration in the storage
+        storage["configuration"]["import_settings"] = self.import_settings
+        storage["configuration"]["import_registry"] = self.import_registry
+        storage["configuration"]["import_users"] = self.import_users
+
         message = "Fetching Data started for {}".format(self.domain_name)
         return True, message
 

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -84,6 +84,9 @@ class ImportStep(SyncStep):
         logger.info("*** Importing Settings: {} ***".format(self.domain_name))
 
         storage = self.get_storage()
+        if not storage["configuration"].get("import_settings", False):
+            return
+
         settings_store = storage["settings"]
         for key in settings_store:
             self._set_settings(key, settings_store[key])
@@ -127,6 +130,9 @@ class ImportStep(SyncStep):
             self.domain_name))
 
         storage = self.get_storage()
+        if not storage["configuration"].get("import_registry", False):
+            return
+
         registry_store = storage["registry"]
         current_registry = getUtility(IRegistry)
         # For each of the keywords used to retrieve registry data
@@ -149,6 +155,10 @@ class ImportStep(SyncStep):
         """Import the users from the storage identified by domain
         """
         logger.info("*** Importing Users: {} ***".format(self.domain_name))
+
+        storage = self.get_storage()
+        if not storage["configuration"].get("import_users", False):
+            return
 
         for user in self.yield_items("users"):
             username = user.get("username")

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -32,6 +32,10 @@ class SyncStep:
         self.domain_name = data.get("domain_name", None)
         self.username = data.get("ac_name", None)
         self.password = data.get("ac_password", None)
+        # Import configuration
+        self.import_settings = data.get("import_settings", False)
+        self.import_users = data.get("import_users", False)
+        self.import_registry = data.get("import_registry", False)
 
         if not any([self.domain_name, self.url, self.username, self.password]):
             self.fail("Missing parameter in Sync Step: {}".format(data))
@@ -142,6 +146,7 @@ class SyncStep:
             self.storage[domain]["registry"] = OOBTree()
             self.storage[domain]["settings"] = OOBTree()
             self.storage[domain]["ordered_uids"] = []
+            self.storage[domain]["configuration"] = OOBTree()
         return self.storage[domain]
 
     @property


### PR DESCRIPTION
**Note**: #16 has to be accepted first in order to to include the content type filtering logic in this PR as well as its visualization. Until then this PR won't be ready for merge.

## Description of the issue/feature this PR addresses

This PR adds a new functionality to `senaite.sync`. It gives the user the possibility to select and configure which is the desired data to be imported from the source instance to the target instance.

## Current behavior before PR

In each migration/import process everything was imported (LIMS objects, settings, registry and users).

## Desired behavior after PR is merged

The user can choose what will be imported. By clicking over "Show import configuration" (collapsed by default) in the view of `sync` the following set of options will be presented to the user (see the first attached image):
1. A **checkbox** that allows to choose whether the **settings** will be imported or not.
2. A **checkbox** that allows to choose whether the **registry** will be imported or not.
3. A **checkbox** that allows to choose whether the **users** will be imported or not.
4. A **textbox** that allows the user to specify which **content types** will be imported.

**Important**: By default the checkboxes are not checked and the textbox is empty.

For the already fetched sources it will also show the settings that where specified when the fetch was performed (see second attached image).

## Screenshot (optional)
#### Import configuration view 
![selection_002](https://user-images.githubusercontent.com/9968427/36263049-7e8e3076-1269-11e8-9fdb-19cea5b05cb7.png)
#### Fetched data 
![selection_003](https://user-images.githubusercontent.com/9968427/36263647-ec5bba46-126a-11e8-8ee0-04e4627f7aae.png)



--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008

