### PR TITLE
Fix missing div tag in Sync view 

### DIFF
--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -178,8 +178,9 @@
                                name="content_types"/>
                       </div>
                     </div>
-                </li>
-              </ul>
+                  </li>
+                </ul>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #23 

The Sync view was being placed in the wrong place when `senaite.lims` add-on was not active. There was a missing div closing tag which was the culprit of it.

## Current behavior before PR

Sync view wasn't correctly placed in the page.

## Desired behavior after PR is merged

Sync view is correctly placed in the page.

## Screenshot (optional)

![seleccio_003](https://user-images.githubusercontent.com/9968427/36592576-9d97709e-1896-11e8-922a-9bf54f212b87.png)

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008