### PR TITLE
Import Fails because of removed 'folderish' Content Types.

### DIFF
--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -118,9 +118,7 @@ class FetchStep(SyncStep):
                     start_from, start_from+window))
             for item in items:
                 # skip object or extract the required data for the import
-                if not utils.is_item_allowed(item):
-                    logger.debug("Skipping unnecessary/unknown portal type: {}"
-                                 .format(item))
+                if not item or not item.get("portal_type", True):
                     continue
                 data_dict = utils.get_soup_format(item)
                 rec_id = self.sh.insert(data_dict)

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -6,14 +6,13 @@ import transaction
 
 from BTrees.OOBTree import OOBTree
 
-from senaite.sync.syncstep import SyncStep
+from senaite import api
 
+from senaite.sync.syncstep import SyncStep
 from senaite.sync import logger
 from senaite.sync import _
 from senaite.sync.souphandler import SoupHandler
 from senaite.sync import utils
-
-SKIP_PORTAL_TYPES = ["SKIP"]
 
 
 class FetchStep(SyncStep):
@@ -119,8 +118,8 @@ class FetchStep(SyncStep):
                     start_from, start_from+window))
             for item in items:
                 # skip object or extract the required data for the import
-                if item.get("portal_type", "SKIP") in SKIP_PORTAL_TYPES:
-                    logger.debug("Skipping unnecessary portal type: {}"
+                if not utils.is_item_allowed(item):
+                    logger.debug("Skipping unnecessary/unknown portal type: {}"
                                  .format(item))
                     continue
                 data_dict = utils.get_soup_format(item)

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -123,7 +123,8 @@ class FetchStep(SyncStep):
                 data_dict = utils.get_soup_format(item)
                 rec_id = self.sh.insert(data_dict)
                 ordered_uids.insert(0, data_dict['remote_uid'])
-                self._fetch_missing_parents(item)
+                if not self._parents_fetched(item):
+                    logger.warning("Some parents are missing: {} ".format(item))
 
             logger.info("{} of {} pages fetched...".format(current_page+1,
                                                            number_of_pages))

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -321,6 +321,10 @@ class ImportStep(SyncStep):
         if p_path == "/":
             return True
 
+        # Skip if its the portal object.
+        if self.is_portal_path(p_path):
+            return True
+
         # Incoming path was remote path, translate it into local one
         local_path = self.translate_path(p_path)
 
@@ -329,9 +333,6 @@ class ImportStep(SyncStep):
 
         existing = self.portal.unrestrictedTraverse(local_path, None)
         if existing:
-            # Skip if its the portal object.
-            if self.is_portal_path(p_path):
-                return False
             p_row = self.sh.find_unique("path", p_path)
             if p_row is None:
                 return False

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -295,7 +295,7 @@ class ImportStep(SyncStep):
                 self.sh.update_by_path(path, local_uid=local_uid)
             return existing
 
-        if not self._create_parents(path):
+        if not self._parents_created(path):
             logger.warning("Parent creation failed, skipping: {}".format(path))
             return None
 
@@ -310,10 +310,9 @@ class ImportStep(SyncStep):
             self.sh.update_by_path(path, local_uid=local_uid)
         return obj
 
-    def _create_parents(self, path):
-        """
-        Creates all non-existing parents and updates local UIDs for the existing
-        ones.
+    def _parents_created(self, path):
+        """ Check if parents have been already created and create all non-existing
+        parents and updates local UIDs for the existing ones.
         :param path: object path in the remote
         :return: True if ALL the parents were created successfully
         """
@@ -345,7 +344,7 @@ class ImportStep(SyncStep):
 
         # Before creating an object's parent, make sure grand parents are
         # already ready.
-        if not self._create_parents(p_path):
+        if not self._parents_created(p_path):
             return False
         parent = self.sh.find_unique("path", p_path)
         grand_parent = self.translate_path(utils.get_parent_path(p_path))

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -342,6 +342,9 @@ class ImportStep(SyncStep):
             "id": utils.get_id_from_path(p_path),
             "portal_type": parent.get("portal_type")}
         parent_obj = self._create_object_slug(container, parent_data)
+        if parent_obj is None:
+            logger.warning("Couldn't create parent of {}".format(path))
+            return False
 
         # Parent is created, update it in the soup table.
         p_local_uid = api.get_uid(parent_obj)

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -409,7 +409,7 @@ class ImportStep(SyncStep):
                 data_dict = utils.get_soup_format(dep_item)
                 rec_id = self.sh.insert(data_dict)
                 dep_row = self.sh.get_record_by_id(rec_id, as_dict=True)
-                if self._fetch_missing_parents(dep_item):
+                if self._parents_fetched(dep_item):
                     self._handle_obj(dep_row, handle_dependencies=False)
                 continue
 

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -410,8 +410,8 @@ class ImportStep(SyncStep):
                 data_dict = utils.get_soup_format(dep_item)
                 rec_id = self.sh.insert(data_dict)
                 dep_row = self.sh.get_record_by_id(rec_id, as_dict=True)
-                self._fetch_missing_parents(dep_item)
-                self._handle_obj(dep_row, handle_dependencies=False)
+                if self._fetch_missing_parents(dep_item):
+                    self._handle_obj(dep_row, handle_dependencies=False)
                 continue
 
             # If Dependency is being processed, skip it.

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -390,6 +390,10 @@ class ImportStep(SyncStep):
                     logger.error("Remote UID not found in fetched data: {}".
                                  format(r_uid))
                     continue
+                if not utils.is_item_allowed(dep_item):
+                    logger.error("Skipping dependency with unknown portal type:"
+                                 " {}".format(dep_item))
+                    continue
                 data_dict = utils.get_soup_format(dep_item)
                 rec_id = self.sh.insert(data_dict)
                 dep_row = self.sh.get_record_by_id(rec_id, as_dict=True)

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -330,7 +330,6 @@ class ImportStep(SyncStep):
 
         # Check if the parent already exists. If yes, make sure it has
         # 'local_uid' value set in the soup table.
-
         existing = self.portal.unrestrictedTraverse(local_path, None)
         if existing:
             p_row = self.sh.find_unique("path", p_path)
@@ -353,6 +352,7 @@ class ImportStep(SyncStep):
         container = self.portal.unrestrictedTraverse(str(grand_parent), None)
         parent_data = {
             "id": utils.get_id_from_path(p_path),
+            "path": p_path,
             "portal_type": parent.get("portal_type")}
         parent_obj = self._create_object_slug(container, parent_data)
         if parent_obj is None:
@@ -517,12 +517,12 @@ class ImportStep(SyncStep):
         """Create an content object slug for the given data
         """
         id = data.get("id")
-        path = data.get("path")
+        remote_path = data.get("path")
         portal_type = data.get("portal_type")
         types_tool = api.get_tool("portal_types")
         fti = types_tool.getTypeInfo(portal_type)
         if not fti:
-            self.skipped.append(path)
+            self.skipped.append(remote_path)
             logger.error("Type Info not found for {}".format(portal_type))
             return None
         logger.debug("Creating {} with ID {} in parent path {}".format(

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -196,17 +196,17 @@ class SyncStep(object):
         """
         # Never fetch parents of an unnecessary objects
         if not utils.is_item_allowed(item):
-            return
+            return False
         parent_path = item.get("parent_path")
         # Skip if the parent is portal object
         if self.is_portal_path(parent_path):
-            return
+            return True
         # Skip if already exists
         if self.sh.find_unique("path", parent_path):
-            return
+            return True
         logger.debug("Inserting missing parent: {}".format(parent_path))
         parent = self.get_first_item(item.get("parent_url"))
         par_dict = utils.get_soup_format(parent)
         self.sh.insert(par_dict)
         # Recursively import grand parents too
-        self._fetch_missing_parents(parent)
+        return self._fetch_missing_parents(parent)

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -194,6 +194,9 @@ class SyncStep(object):
         to fill the missing parents for fetched objects.
         :return:
         """
+        # Never fetch parents of an unnecessary objects
+        if not utils.is_item_allowed(item):
+            return
         parent_path = item.get("parent_path")
         # Skip if the parent is portal object
         if self.is_portal_path(parent_path):

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -188,11 +188,11 @@ class SyncStep(object):
         if annotation.get(SYNC_STORAGE) is not None:
             del annotation[SYNC_STORAGE]
 
-    def _fetch_missing_parents(self, item):
+    def _parents_fetched(self, item):
         """
         If data was fetched with portal type filter, this method will be used
         to fill the missing parents for fetched objects.
-        :return:
+        :return: True if ALL parents are fetched
         """
         # Never fetch parents of an unnecessary objects
         if not utils.is_item_allowed(item):
@@ -209,4 +209,4 @@ class SyncStep(object):
         par_dict = utils.get_soup_format(parent)
         self.sh.insert(par_dict)
         # Recursively import grand parents too
-        return self._fetch_missing_parents(parent)
+        return self._parents_fetched(parent)

--- a/src/senaite/sync/utils.py
+++ b/src/senaite/sync/utils.py
@@ -13,7 +13,6 @@ SOUPER_REQUIRED_FIELDS = {"uid": "remote_uid",
                           "portal_type": "portal_type"}
 
 SYNC_CREDENTIALS = "senaite.sync.credentials"
-SKIP_PORTAL_TYPES = ["SKIP"]
 
 
 def to_review_history_format(review_history):
@@ -31,16 +30,15 @@ def to_review_history_format(review_history):
 
 
 def is_item_allowed(item):
-    """
-    Check if an item can be handled based in its portal type.
-    :return:
+    """ Check if an item can be handled based on its portal type.
+    :return: True if the item can be handled
     """
     if not isinstance(item, dict):
         return False
 
     portal_types = api.get_tool("portal_types")
-    pt = item.get("portal_type", "SKIP")
-    if pt in SKIP_PORTAL_TYPES or pt not in portal_types:
+    pt = item.get("portal_type", None)
+    if pt not in portal_types:
         return False
 
     return True

--- a/src/senaite/sync/utils.py
+++ b/src/senaite/sync/utils.py
@@ -13,6 +13,8 @@ SOUPER_REQUIRED_FIELDS = {"uid": "remote_uid",
                           "portal_type": "portal_type"}
 
 SYNC_CREDENTIALS = "senaite.sync.credentials"
+SKIP_PORTAL_TYPES = ["SKIP"]
+
 
 def to_review_history_format(review_history):
     """
@@ -26,6 +28,22 @@ def to_review_history_format(review_history):
         parsed = datetime.strptime(raw, "%Y-%m-%d %H:%M:%S")
         review_history['time'] = DateTime(parsed)
     return review_history
+
+
+def is_item_allowed(item):
+    """
+    Check if an item can be handled based in its portal type.
+    :return:
+    """
+    if not isinstance(item, dict):
+        return False
+
+    portal_types = api.get_tool("portal_types")
+    pt = item.get("portal_type", "SKIP")
+    if pt in SKIP_PORTAL_TYPES or pt not in portal_types:
+        return False
+
+    return True
 
 
 def get_parent_path(path):


### PR DESCRIPTION
**Current Behavior**
If there is a _folderish_ content type in the source instance, which has been removed in the destination, it causes the import fail for the current object chunk. E.g: While importing an AR, `ARPriorities` folder cannot be created, and all the objects in AR chunk fail.

**Expected Behavior after this PR**
Skip the import for deleted folderish content types as well.