### PR TITLE
Make each checkbox label affect its own checkbox

### DIFF
--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -146,7 +146,7 @@
                       <input type="checkbox"
                              name="import_registry"
                              id="import_registry"/>
-	     	          <label for="import_settings">Import Registry</label>
+	     	          <label for="import_registry">Import Registry</label>
 	                </div>
                   </li>
                   <li class="list-group-item">
@@ -154,7 +154,7 @@
                       <input type="checkbox"
                              name="import_users"
                              id="import_users"/>
-	     	          <label for="import_settings">Import Users</label>
+	     	          <label for="import_users">Import Users</label>
 	                </div>
                   </li>
                   <li class="list-group-item">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Clicking on any checkbox label modifies the state of the settings checkbox.

## Current behavior before PR

Any checkbox label modifies the state of the settings checkbox..

## Desired behavior after PR is merged

Each label modifies the state of its own checkbox.

## Screenshot (optional)

![seleccio_001](https://user-images.githubusercontent.com/9968427/36721580-9917e004-1bab-11e8-9182-43e93a30baab.png)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
