### PR TITLE
Analyses of Worksheets are not in proper Workflow State.

### DIFF
--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -547,7 +547,7 @@ class ImportStep(SyncStep):
             logger.warn("%s: Cannot find workflow id %s" % (content, wf_id))
 
         for rh in sorted(review_history, key=lambda k: k['time']):
-            if not utils.review_history_imported(content, rh, wf_def):
+            if not utils.is_review_history_imported(content, rh, wf_def):
                 portal_workflow.setStatusOf(wf_id, content,
                                             utils.to_review_history_format(rh))
 

--- a/src/senaite/sync/utils.py
+++ b/src/senaite/sync/utils.py
@@ -82,10 +82,11 @@ def review_history_imported(obj, review_history, wf_tool=None):
     if wf_tool is None:
         wf_tool = api.get_tool('portal_workflow')
 
-    state = review_history.get('review_state')
+    state_variable = wf_tool.variables.getStateVar()
+    state = review_history.get(state_variable)
     current_rh = wf_tool.getInfoFor(obj, 'review_history', '')
     for rh in current_rh:
-        if rh.get('review_state') == state:
+        if rh.get(state_variable) == state:
             return True
 
     return False

--- a/src/senaite/sync/utils.py
+++ b/src/senaite/sync/utils.py
@@ -70,14 +70,14 @@ def get_soup_format(item):
     return data_dict
 
 
-def review_history_imported(obj, review_history, wf_tool=None):
+def is_review_history_imported(obj, review_history, wf_tool=None):
     """
     Check if review History info is already imported for given workflow.
     :param obj: the object to be checked
     :param review_history: Review State Dictionary
     :param wf_tool: Objects Workflow tool. Will be set to 'portal_worklow'
             if is None.
-    :return: formatted dictionary
+    :return: True if the state was found in the current review history
     """
     if wf_tool is None:
         wf_tool = api.get_tool('portal_workflow')


### PR DESCRIPTION
**Current Behavior**
When importing analyses, `bika_worksheetanalysis_workflow` states of Analyses are not updated properly and that's why it'is possible to Assign those analyses to another Worksheets. 

**Expected Behavior after this PR**
It happens because State Variable of `bika_worksheetanalysis_workflow` is different than `review_state`. So in all cases, the system must get the State Variable Names from Workflow Definitions.