### PR TITLE
Empty user e-mails.

### DIFF
--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -169,7 +169,7 @@ class ImportStep(SyncStep):
                 continue
             email = user.get("email", "")
             if not email:
-                email = "example@example.com"
+                email = "{}@example.com".format(username)
             roles = user.get("roles", ())
             groups = user.get("groups", ())
             logger.debug("Creating user {}".format(username))

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -168,6 +168,8 @@ class ImportStep(SyncStep):
                 logger.debug("Skipping existing user {}".format(username))
                 continue
             email = user.get("email", "")
+            if not email:
+                email = "example@example.com"
             roles = user.get("roles", ())
             groups = user.get("groups", ())
             logger.debug("Creating user {}".format(username))


### PR DESCRIPTION
**Current behavior**
If a user doesn't have any e-mail set in the source, then system fails to create that user in the destination.

**Expected behavior after this PR**
If a user doesn't have an e-mail set, set it to default value- `example@example.com`.