### PR TITLE
 'Recover' step in Data Import for failed objects.

### DIFF
--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -606,15 +606,16 @@ class ImportStep(SyncStep):
         query = AdvancedQuery.Eq('Title', '') & ~ AdvancedQuery.Eq(
                                                     'portal_type', 'Reference')
         brains = uc.evalAdvancedQuery(query)
-
-        for brain in brains:
+        total = len(brains)
+        logger.info('*** Recovering {} objects ***'.format(total))
+        for idx, brain in enumerate(brains):
             # Check if object has been created during migration
             uid = brain.UID
             existing = self.sh.find_unique(LOCAL_UID, uid)
             if existing is None:
                 continue
-            logger.info("Handling non-updated object: {} ".format(
-                            existing["path"]))
+            logger.info('Recovering {0}/{1} : {2} '.format(
+                                                idx+1, total, existing["path"]))
             # Mark that update failed previously
             existing['updated'] = '0'
             self._handle_obj(existing, handle_dependencies=False)

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -6,6 +6,7 @@ import requests
 import transaction
 
 from Products.CMFPlone.utils import _createObjectByType
+from Products import AdvancedQuery
 from datetime import datetime
 from senaite.jsonapi.fieldmanagers import ProxyFieldManager
 from senaite.jsonapi.fieldmanagers import ComputedFieldManager
@@ -245,6 +246,9 @@ class ImportStep(SyncStep):
 
         # Delete the UID list from the storage.
         storage["ordered_uids"] = []
+
+        self._recover_failed_objects()
+
         # Mark all objects as non-updated for the next import.
         self.sh.reset_updated_flags()
 
@@ -590,4 +594,28 @@ class ImportStep(SyncStep):
                                             utils.to_review_history_format(rh))
 
         wf_def.updateRoleMappingsFor(content)
+        return
+
+    def _recover_failed_objects(self):
+        """ Checks for non-updated objects (by filtering null Title) and
+        re-updates them.
+        :return:
+        """
+        uc = api.get_tool('uid_catalog', self.portal)
+        # Reference objects must be skipped
+        query = AdvancedQuery.Eq('Title', '') & ~ AdvancedQuery.Eq(
+                                                    'portal_type', 'Reference')
+        brains = uc.evalAdvancedQuery(query)
+
+        for brain in brains:
+            # Check if object has been created during migration
+            uid = brain.UID
+            existing = self.sh.find_unique(LOCAL_UID, uid)
+            if existing is None:
+                continue
+            logger.info("Handling non-updated object: {} ".format(
+                            existing["path"]))
+            # Mark that update failed previously
+            existing['updated'] = '0'
+            self._handle_obj(existing, handle_dependencies=False)
         return

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -619,4 +619,6 @@ class ImportStep(SyncStep):
             # Mark that update failed previously
             existing['updated'] = '0'
             self._handle_obj(existing, handle_dependencies=False)
+            obj = brain.getObject()
+            obj.reindexObject()
         return

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -6,7 +6,7 @@ import requests
 import transaction
 
 from Products.CMFPlone.utils import _createObjectByType
-from Products import AdvancedQuery
+from Products.AdvancedQuery import Eq
 from datetime import datetime
 from senaite.jsonapi.fieldmanagers import ProxyFieldManager
 from senaite.jsonapi.fieldmanagers import ComputedFieldManager
@@ -603,8 +603,8 @@ class ImportStep(SyncStep):
         """
         uc = api.get_tool('uid_catalog', self.portal)
         # Reference objects must be skipped
-        query = AdvancedQuery.Eq('Title', '') & ~ AdvancedQuery.Eq(
-                                                    'portal_type', 'Reference')
+        query = Eq('Title', '') & ~ Eq('portal_type', 'Reference') & ~ \
+            Eq('portal_type', 'ARReport')
         brains = uc.evalAdvancedQuery(query)
         total = len(brains)
         logger.info('*** Recovering {} objects ***'.format(total))


### PR DESCRIPTION
When migrating a DB with big amount of objects, it is possible that some objects won't be updated properly because of unpredictable reasons (e.g: http connection fails and etc.). We observed that it happens to 5-15 objects when there are ~ 500.000 objects in total to be migrated. 
With this PR, we will have a recover step for that kind of objects. To identify those objects, we will query them by empty values in 'Title' field, since all objects in the source instance must have a 'Title'.