### PR TITLE
New Complement Step for Migration

### DIFF
--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -205,18 +205,15 @@
               Data for <span tal:replace="storage"/>
               (<span tal:replace="python:len(view.storage[storage]['ordered_uids'])"/> Items)
             </dt>
-
-            <dl class="collapsible">
-              Import settings: <span tal:replace="python:view.storage[storage]['configuration'].get('import_settings')"/>,
-              Import registry: <span tal:replace="python:view.storage[storage]['configuration'].get('import_registry')"/>,
-              Import users: <span tal:replace="python:view.storage[storage]['configuration'].get('import_users')"/>
-            </dl>
-
             <input type="hidden" name="dataform" value="1"/>
             <input type="hidden" name="domain_name" value="" tal:attributes="value storage" />
 
             <dd class="collapsibleContent">
-
+              <div>
+                  Import settings: <span tal:replace="python:view.storage[storage]['configuration'].get('import_settings')"/>
+                  Import registry: <span tal:replace="python:view.storage[storage]['configuration'].get('import_registry')"/>
+                  Import users: <span tal:replace="python:view.storage[storage]['configuration'].get('import_users')"/>
+              </div><br>
               <input class="btn btn-default btn-sm"
                      type="submit"
                      name="import"
@@ -225,16 +222,42 @@
 
               <input class="btn btn-default btn-sm"
                      type="submit"
-                     name="complement"
-                     i18n:attributes="value"
-                     value="Complement"/>
-
-              <input class="btn btn-default btn-sm"
-                     type="submit"
                      onclick="return confirm('Are you sure you want to delete all the fetched data?');"
                      name="clear_storage"
                      i18n:attributes="value"
                      value="Clear this Storage"/>
+              <div>
+                  <dl class="collapsible">
+                      <dt class="collapsibleHeader">
+                          Complement Step
+                      </dt>
+                      <dd class="collapsibleContent">
+                          <div class="field form-group field">
+                              <label i18n:translate=""
+                                     class="form-control-label"
+                                     for="mod_date_limit">
+                                Modification Date Limit
+                                <span i18n:translate=""
+                                      class="help formHelp">
+                                  If filled, complement step will run for the objects created/modified after this time.
+                                </span>
+                              </label>
+                              <div class="form-group input-group">
+                                <input type="text"
+                                       size="25"
+                                       class="form-control"
+                                       id="mod_date_limit"
+                                       name="mod_date_limit"/>
+                                </div>
+                          </div>
+                          <input class="btn btn-default btn-sm"
+                                 type="submit"
+                                 name="complement"
+                                 i18n:attributes="value"
+                                 value="Complement"/>
+                      </dd>
+                  </dl>
+              </div>
             </dd>
           </dl>
         </form>

--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -225,6 +225,12 @@
 
               <input class="btn btn-default btn-sm"
                      type="submit"
+                     name="complement"
+                     i18n:attributes="value"
+                     value="Complement"/>
+
+              <input class="btn btn-default btn-sm"
+                     type="submit"
                      onclick="return confirm('Are you sure you want to delete all the fetched data?');"
                      name="clear_storage"
                      i18n:attributes="value"

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -2,7 +2,7 @@
 #
 # Copyright 2017-2017 SENAITE LIMS.
 
-from datetime import datetime
+from DateTime import DateTime
 from BTrees.OOBTree import OOBTree
 
 from Products.Five import BrowserView
@@ -82,7 +82,7 @@ class Sync(BrowserView):
             domain_name = form.get("domain_name", None)
             storage = self.get_storage(domain_name)
             fetch_time = storage.get("last_fetch_time", None)
-            if not isinstance(fetch_time, datetime):
+            if not isinstance(fetch_time, DateTime):
                 message = 'Cannot get last fetched time, please re-run the ' \
                           'Fetch step.'
                 self.add_status_message(message, "error")

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -84,13 +84,11 @@ class Sync(BrowserView):
 
             fetch_time = form.get("mod_date_limit", None) or \
                 storage.get("last_fetch_time", None)
-
             if not fetch_time:
                 message = 'Cannot get last fetched time, please re-run ' \
                           'the Fetch step.'
                 self.add_status_message(message, "error")
                 return self.template()
-
             if isinstance(fetch_time, str):
                 try:
                     fetch_time = DateTime(fetch_time)

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -81,12 +81,23 @@ class Sync(BrowserView):
         if form.get("complement", False):
             domain_name = form.get("domain_name", None)
             storage = self.get_storage(domain_name)
-            fetch_time = storage.get("last_fetch_time", None)
-            if not isinstance(fetch_time, DateTime):
-                message = 'Cannot get last fetched time, please re-run the ' \
-                          'Fetch step.'
+
+            fetch_time = form.get("mod_date_limit", None) or \
+                storage.get("last_fetch_time", None)
+
+            if not fetch_time:
+                message = 'Cannot get last fetched time, please re-run ' \
+                          'the Fetch step.'
                 self.add_status_message(message, "error")
                 return self.template()
+
+            if isinstance(fetch_time, str):
+                try:
+                    fetch_time = DateTime(fetch_time)
+                except:
+                    message = 'Please enter a valid Date & Time'
+                    self.add_status_message(message, "error")
+                    return self.template()
 
             url = storage["credentials"]["url"]
             username = storage["credentials"]["username"]

--- a/src/senaite/sync/complementstep.py
+++ b/src/senaite/sync/complementstep.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2018 SENAITE SYNC.
+
+from senaite.sync.importstep import ImportStep
+
+from senaite.sync import logger
+
+
+class ComplementStep(ImportStep):
+    """ Class for the Import step of the Synchronization. It must create and
+    update objects based on previously fetched data.
+
+    """
+
+    def __init__(self, data):
+        ImportStep.__init__(self, data)
+        self.fetch_time = data.get("fetch_time", None)
+
+    def run(self):
+        """
+        :return:
+        """
+        self.session = self.get_session()
+        return
+

--- a/src/senaite/sync/complementstep.py
+++ b/src/senaite/sync/complementstep.py
@@ -13,7 +13,9 @@ from senaite.sync.souphandler import SoupHandler, REMOTE_UID, LOCAL_UID
 
 
 class ComplementStep(ImportStep):
-    """
+    """ A Complement Step to be run after the Import Step. Might be useful when
+    import takes too long and there are objects that have been created during
+    that time.
     """
 
     def __init__(self, data):
@@ -30,13 +32,15 @@ class ComplementStep(ImportStep):
         return
 
     def _fetch_data(self):
+        """ Fetch necessary objects and save their UIDs in memory.
         """
-        """
-        logger.info("*** FETCHING DATA: {} ***".format(
+        logger.info("*** COMPLEMENT STEP - FETCHING DATA: {} ***".format(
             self.domain_name))
 
         self.uids = []
         self.sh = SoupHandler(self.domain_name)
+
+        # TODO: Find another way to do it without waking up objects.
         query = {
             "url_or_endpoint": "search",
             "catalog": 'uid_catalog',
@@ -58,8 +62,7 @@ class ComplementStep(ImportStep):
         return
 
     def _import_missing_objects(self):
-        """
-        For each UID from the fetched data, creates and updates objects
+        """ For each UID from the fetched data, creates and updates objects
         step by step.
         :return:
         """
@@ -90,20 +93,21 @@ class ComplementStep(ImportStep):
             self.uids_to_reindex = []
 
             # Log.info every 50 objects imported
-            utils.log_process(task_name="Data Complement", started=start_time,
+            utils.log_process(task_name="Complement Step", started=start_time,
                               processed=item_index+1, total=total_object_count,
                               frequency=50)
 
         # Delete the UID list from the storage.
         storage["ordered_uids"] = []
-        logger.info("DONE !!!")
+
         # Mark all objects as non-updated for the next import.
         self.sh.reset_updated_flags()
 
         return
 
     def _yield_items(self, url_or_endpoint, **kw):
-        """Yield items of all pages
+        """ Walk through all objects and yield items filtering by their
+        modification date.
         """
         data = self.get_json(url_or_endpoint, **kw)
         for item in data.get("items", []):

--- a/src/senaite/sync/complementstep.py
+++ b/src/senaite/sync/complementstep.py
@@ -2,15 +2,18 @@
 #
 # Copyright 2017-2018 SENAITE SYNC.
 
+from datetime import datetime
+from DateTime import DateTime
+
+from senaite import api
 from senaite.sync.importstep import ImportStep
 
-from senaite.sync import logger
+from senaite.sync import logger, utils
+from senaite.sync.souphandler import SoupHandler, REMOTE_UID, LOCAL_UID
 
 
 class ComplementStep(ImportStep):
-    """ Class for the Import step of the Synchronization. It must create and
-    update objects based on previously fetched data.
-
+    """
     """
 
     def __init__(self, data):
@@ -22,5 +25,108 @@ class ComplementStep(ImportStep):
         :return:
         """
         self.session = self.get_session()
+        self._fetch_data()
+        self._import_missing_objects()
         return
 
+    def _fetch_data(self):
+        """
+        """
+        logger.info("*** FETCHING DATA: {} ***".format(
+            self.domain_name))
+
+        self.ordered_uids = []
+        self.sh = SoupHandler(self.domain_name)
+        # Dummy query to get overall number of items in the specified catalog
+        query = {
+            "url_or_endpoint": "search",
+            "catalog": 'uid_catalog',
+            "b_start": 0,
+            "complete": "yes",
+            "limit": 10
+        }
+        if self.content_types:
+            query["portal_type"] = self.content_types
+        # cd = self.get_json(**query)
+        # total = cd['count']
+        # b_start = total - 10
+        # query["b_start"] = b_start
+        # query["complete"] = 'yes'
+        # query["limit"] = 10
+        items = self._yield_items(self.fetch_time, **query)
+
+        for item in items:
+            # skip object or extract the required data for the import
+            if not item or not item.get("portal_type", True):
+                continue
+            data_dict = utils.get_soup_format(item)
+            rec_id = self.sh.insert(data_dict)
+            self.ordered_uids.insert(0, data_dict[REMOTE_UID])
+
+        return
+
+    def _import_missing_objects(self):
+        """
+        For each UID from the fetched data, creates and updates objects
+        step by step.
+        :return:
+        """
+        logger.info("*** IMPORT DATA STARTED: {} ***".format(self.domain_name))
+
+        self.sh = SoupHandler(self.domain_name)
+        self.uids_to_reindex = []
+        storage = self.get_storage()
+        total_object_count = len(self.ordered_uids)
+        start_time = datetime.now()
+
+        for item_index, r_uid in enumerate(self.ordered_uids):
+            row = self.sh.find_unique(REMOTE_UID, r_uid)
+            logger.debug("Handling: {} ".format(row["path"]))
+            self._handle_obj(row, handle_dependencies=False)
+
+            # Handling object means there is a chunk containing several objects
+            # which have been created and updated. Reindex them now.
+            self.uids_to_reindex = list(set(self.uids_to_reindex))
+            for uid in self.uids_to_reindex:
+                try:
+                    obj = api.get_object_by_uid(uid)
+                    obj.reindexObject()
+                except Exception, e:
+                    rec = self.sh.find_unique(LOCAL_UID, uid)
+                    logger.error("Error while reindexing {} - {}"
+                                 .format(rec, e))
+            self.uids_to_reindex = []
+
+            # Log.info every 50 objects imported
+            utils.log_process(task_name="Data Import", started=start_time,
+                              processed=item_index+1, total=total_object_count,
+                              frequency=50)
+
+        # Delete the UID list from the storage.
+        storage["ordered_uids"] = []
+        logger.info("DONE !!!")
+        # Mark all objects as non-updated for the next import.
+        self.sh.reset_updated_flags()
+
+        return
+
+    def _yield_items(self, modified_date_limit, url_or_endpoint, **kw):
+        """Yield items of all pages
+        """
+        data = self.get_json(url_or_endpoint, **kw)
+        enough = False
+        for item in data.get("items", []):
+            if not item:
+                continue
+            modified = DateTime(item.get('modified'))
+            if modified > modified_date_limit:
+                enough = True
+                continue
+            else:
+                yield item
+
+        if not enough:
+            next_url = data.get("next")
+            if next_url:
+                for item in self.yield_items(next_url, **kw):
+                    yield item

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -66,6 +66,7 @@ class FetchStep(SyncStep):
         storage["configuration"]["import_settings"] = self.import_settings
         storage["configuration"]["import_registry"] = self.import_registry
         storage["configuration"]["import_users"] = self.import_users
+        storage["last_fetch_time"] = datetime.now()
 
         message = "Fetching Data started for {}".format(self.domain_name)
         return True, message

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -7,6 +7,7 @@ import transaction
 from BTrees.OOBTree import OOBTree
 
 from datetime import datetime
+from DateTime import DateTime
 
 from senaite import api
 from senaite.sync.syncstep import SyncStep
@@ -66,7 +67,7 @@ class FetchStep(SyncStep):
         storage["configuration"]["import_settings"] = self.import_settings
         storage["configuration"]["import_registry"] = self.import_registry
         storage["configuration"]["import_users"] = self.import_users
-        storage["last_fetch_time"] = datetime.now()
+        storage["last_fetch_time"] = DateTime()
 
         message = "Fetching Data started for {}".format(self.domain_name)
         return True, message

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -6,7 +6,7 @@ import urllib
 import urlparse
 import requests
 
-from datetime import datetime
+from DateTime import DateTime
 
 from BTrees.OOBTree import OOBTree
 from zope.annotation.interfaces import IAnnotations
@@ -170,7 +170,7 @@ class SyncStep(object):
             self.storage[domain]["settings"] = OOBTree()
             self.storage[domain]["ordered_uids"] = []
             self.storage[domain]["configuration"] = OOBTree()
-            self.storage[domain]["last_fetch_time"] = datetime.now()
+            self.storage[domain]["last_fetch_time"] = DateTime()
         return self.storage[domain]
 
     @property

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -6,6 +6,8 @@ import urllib
 import urlparse
 import requests
 
+from datetime import datetime
+
 from BTrees.OOBTree import OOBTree
 from zope.annotation.interfaces import IAnnotations
 from senaite import api
@@ -168,6 +170,7 @@ class SyncStep(object):
             self.storage[domain]["settings"] = OOBTree()
             self.storage[domain]["ordered_uids"] = []
             self.storage[domain]["configuration"] = OOBTree()
+            self.storage[domain]["last_fetch_time"] = datetime.now()
         return self.storage[domain]
 
     @property


### PR DESCRIPTION
**Current Behavior**
When migration process takes too long and there are changes (or newly created objects) in the source instance, those objects will not be properly updated in the destination instance.

**Desired Behavior**
With this PR, a new Complement Step can be added to the end of the migration. When migration is done, from the Sync view user can run the Complement Step easily.
User can define a date which objects modified/created after it will be re-fetched and imported as well. If not defined, last fetch time will be the date limit.

*Domain Section of Sync view would look like in the following image:*

![image](https://user-images.githubusercontent.com/23520079/37711385-d8acd14a-2d10-11e8-9693-02ea771af779.png)
