### PR TITLE
Bug- Complement Step yields all the items.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #35 Bug- Complement Step yields all the items
 
 **Security**
 

--- a/src/senaite/sync/complementstep.py
+++ b/src/senaite/sync/complementstep.py
@@ -116,7 +116,7 @@ class ComplementStep(ImportStep):
 
         next_url = data.get("next")
         if next_url:
-            for item in self.yield_items(next_url, **kw):
+            for item in self._yield_items(next_url):
                 if not item:
                     continue
                 modified = DateTime(item.get('modification_date'))


### PR DESCRIPTION
**Current Behavior**
While fetching data, yield items function returns all the items without checking their modification date.

**Expected Behavior after this PR**
During Fetch, only recently modified objects must be retrieved.