### PR TITLE
Add issue and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Steps to reproduce
+
+
+
+## Current behavior
+
+
+
+## Expected behavior
+
+
+
+## Screenshot (optional)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Description of the issue/feature this PR addresses
 
-Linked issue: https://github.com/senaite/senaite.api/issues/
+Linked issue: https://github.com/senaite/senaite.sync/issues/
 
 ## Current behavior before PR
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Description of the issue/feature this PR addresses
 
-
+Linked issue: https://github.com/senaite/senaite.api/issues/
 
 ## Current behavior before PR
 
@@ -11,7 +11,8 @@
 
 
 --
-I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
-standards.
+I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
+and [Plone's Python styleguide][2] standards.
 
 [1]: https://www.python.org/dev/peps/pep-0008
+[2]: https://docs.plone.org/develop/styleguide/python.html

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Description of the issue/feature this PR addresses
+
+
+
+## Current behavior before PR
+
+
+
+## Desired behavior after PR is merged
+
+
+
+--
+I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
+standards.
+
+[1]: https://www.python.org/dev/peps/pep-0008


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Add templates for both issues and Pull Requests.

## Current behavior before PR

There are no templates for issues and Pull Requests

## Desired behavior after PR is merged

When a new issue or Pull Request is created the appropriate template is automatically loaded 

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
