### PR TITLE
New Advanced Configuration Options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #42 New Advanced Configuration Options
 - #34 Complement step for migration
 - #33 Recover step for failed objects in data import
 - #32 Log the estimated date of end

--- a/src/senaite/sync/browser/add.py
+++ b/src/senaite/sync/browser/add.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2018 SENAITE SYNC.
+
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from plone import protect
+from senaite import api
+from senaite.sync import _
+from senaite.sync.browser.interfaces import ISync
+from senaite.sync.browser.views import Sync
+from senaite.sync.fetchstep import FetchStep
+from zope.interface import implements
+
+SYNC_STORAGE = "senaite.sync"
+
+
+class Add(Sync):
+    """ Add new sync instance view
+    """
+    implements(ISync)
+
+    template = ViewPageTemplateFile("templates/add.pt")
+
+    def __init__(self, context, request):
+        super(Sync, self).__init__(context, request)
+
+    def __call__(self):
+        protect.CheckAuthenticator(self.request.form)
+
+        self.portal = api.get_portal()
+        self.request.set('disable_plone.rightcolumn', 1)
+        self.request.set('disable_border', 1)
+
+        # Handle form submit
+        form = self.request.form
+        fetchform = form.get("fetchform", False)
+        dataform = form.get("dataform", False)
+        if not any([fetchform, dataform]):
+            return self.template()
+
+        # Handle "Fetch" action
+        if form.get("fetch", False):
+
+            url = form.get("url", "")
+            if not url.startswith("http"):
+                url = "http://{}".format(url)
+            domain_name = form.get("domain_name", None)
+            username = form.get("ac_name", None)
+            password = form.get("ac_password", None)
+            # check if all mandatory fields have values
+            if not all([domain_name, url, username, password]):
+                message = _("Please fill in all required fields")
+                self.add_status_message(message, "error")
+                return self.template()
+
+            import_settings = True if form.get("import_settings") == 'on' else False
+            import_users = True if form.get("import_users") == 'on' else False
+            import_registry = True if form.get("import_registry") == 'on' else False
+            content_types = form.get("content_types", None)
+            if content_types is not None:
+                content_types = [t.strip() for t in content_types.split(",")]
+                portal_types = api.get_tool("portal_types")
+                content_types = filter(lambda ct: ct in portal_types,
+                                       content_types)
+
+            data = {
+                "url": url,
+                "domain_name": domain_name,
+                "ac_name": username,
+                "ac_password": password,
+                "content_types": content_types,
+                "import_settings": import_settings,
+                "import_users": import_users,
+                "import_registry": import_registry,
+            }
+
+            fs = FetchStep(data)
+            verified, message = fs.verify()
+            if verified:
+                fs.run()
+                self.add_status_message(message, "info")
+            else:
+                self.add_status_message(message, "error")
+
+        # render the template
+        return self.template()

--- a/src/senaite/sync/browser/add.py
+++ b/src/senaite/sync/browser/add.py
@@ -78,6 +78,11 @@ class Add(Sync):
 
             # Content Type Validation
             if prefixable_types is not None:
+                if not prefix:
+                    self.add_status_message("Please enter a valid Prefix.",
+                                            "error")
+                    return self.template()
+
                 prefixable_types = [t.strip() for t in prefixable_types.split(",")]
                 portal_types = api.get_tool("portal_types")
                 prefixable_types = filter(lambda ct: ct in portal_types,

--- a/src/senaite/sync/browser/add.py
+++ b/src/senaite/sync/browser/add.py
@@ -57,11 +57,23 @@ class Add(Sync):
             import_users = True if form.get("import_users") == 'on' else False
             import_registry = True if form.get("import_registry") == 'on' else False
             content_types = form.get("content_types", None)
+            prefix = form.get("prefix", None)
+
+            # Content Type Validation
             if content_types is not None:
                 content_types = [t.strip() for t in content_types.split(",")]
                 portal_types = api.get_tool("portal_types")
                 content_types = filter(lambda ct: ct in portal_types,
                                        content_types)
+
+            # Prefix Validation
+            if prefix:
+                prefix = prefix.strip(u"*.!$%&/()=-+:'`´^")
+                if not prefix:
+                    self.add_status_message("Invalid Prefix!", "error")
+                    return self.template()
+                if len(prefix) > 3:
+                    self.add_status_message("Long Prefix!", "warning")
 
             data = {
                 "url": url,
@@ -72,6 +84,7 @@ class Add(Sync):
                 "import_settings": import_settings,
                 "import_users": import_users,
                 "import_registry": import_registry,
+                "prefix": prefix,
             }
 
             fs = FetchStep(data)

--- a/src/senaite/sync/browser/add.py
+++ b/src/senaite/sync/browser/add.py
@@ -57,15 +57,23 @@ class Add(Sync):
             import_users = True if form.get("import_users") == 'on' else False
             import_registry = True if form.get("import_registry") == 'on' else False
             content_types = form.get("content_types", None)
+            unwanted_content_types = form.get("unwanted_content_types", None)
             prefix = form.get("prefix", None)
             prefixable_types = form.get("prefixable_types", None)
+
+            portal_types = api.get_tool("portal_types")
 
             # Content Type Validation
             if content_types is not None:
                 content_types = [t.strip() for t in content_types.split(",")]
-                portal_types = api.get_tool("portal_types")
                 content_types = filter(lambda ct: ct in portal_types,
                                        content_types)
+            # Content Type Validation
+            if unwanted_content_types is not None:
+                unwanted_content_types = [t.strip() for t
+                                          in unwanted_content_types.split(",")]
+                unwanted_content_types = filter(lambda ct: ct in portal_types,
+                                                unwanted_content_types)
 
             # Prefix Validation
             if prefix:
@@ -84,7 +92,6 @@ class Add(Sync):
                     return self.template()
 
                 prefixable_types = [t.strip() for t in prefixable_types.split(",")]
-                portal_types = api.get_tool("portal_types")
                 prefixable_types = filter(lambda ct: ct in portal_types,
                                           prefixable_types)
 
@@ -99,6 +106,7 @@ class Add(Sync):
                 "ac_name": username,
                 "ac_password": password,
                 "content_types": content_types,
+                "unwanted_content_types": unwanted_content_types,
                 "import_settings": import_settings,
                 "import_users": import_users,
                 "import_registry": import_registry,

--- a/src/senaite/sync/browser/add.py
+++ b/src/senaite/sync/browser/add.py
@@ -63,12 +63,12 @@ class Add(Sync):
 
             # Content Type Validation
             portal_types = api.get_tool("portal_types")
-            if content_types is not None:
+            if content_types:
                 content_types = [t.strip() for t in content_types.split(",")]
                 content_types = filter(lambda ct: ct in portal_types,
                                        content_types)
 
-            if unwanted_content_types is not None:
+            if unwanted_content_types:
                 unwanted_content_types = [t.strip() for t
                                           in unwanted_content_types.split(",")]
                 unwanted_content_types = filter(lambda ct: ct in portal_types,
@@ -84,7 +84,7 @@ class Add(Sync):
                     self.add_status_message("Long Prefix!", "warning")
 
             # Content Type Validation
-            if prefixable_types is not None:
+            if prefixable_types:
                 if not prefix:
                     self.add_status_message("Please enter a valid Prefix.",
                                             "error")

--- a/src/senaite/sync/browser/add.py
+++ b/src/senaite/sync/browser/add.py
@@ -58,6 +58,7 @@ class Add(Sync):
             import_registry = True if form.get("import_registry") == 'on' else False
             content_types = form.get("content_types", None)
             prefix = form.get("prefix", None)
+            prefixable_types = form.get("prefixable_types", None)
 
             # Content Type Validation
             if content_types is not None:
@@ -75,6 +76,17 @@ class Add(Sync):
                 if len(prefix) > 3:
                     self.add_status_message("Long Prefix!", "warning")
 
+            # Content Type Validation
+            if prefixable_types is not None:
+                prefixable_types = [t.strip() for t in prefixable_types.split(",")]
+                portal_types = api.get_tool("portal_types")
+                prefixable_types = filter(lambda ct: ct in portal_types,
+                                          prefixable_types)
+                if not prefixable_types:
+                    self.add_status_message("Invalid Content Types to be"
+                                            "Prefixified!", "error")
+                    return self.template()
+
             data = {
                 "url": url,
                 "domain_name": domain_name,
@@ -85,6 +97,7 @@ class Add(Sync):
                 "import_users": import_users,
                 "import_registry": import_registry,
                 "prefix": prefix,
+                "prefixable_types": prefixable_types,
             }
 
             fs = FetchStep(data)

--- a/src/senaite/sync/browser/add.py
+++ b/src/senaite/sync/browser/add.py
@@ -61,14 +61,13 @@ class Add(Sync):
             prefix = form.get("prefix", None)
             prefixable_types = form.get("prefixable_types", None)
 
-            portal_types = api.get_tool("portal_types")
-
             # Content Type Validation
+            portal_types = api.get_tool("portal_types")
             if content_types is not None:
                 content_types = [t.strip() for t in content_types.split(",")]
                 content_types = filter(lambda ct: ct in portal_types,
                                        content_types)
-            # Content Type Validation
+
             if unwanted_content_types is not None:
                 unwanted_content_types = [t.strip() for t
                                           in unwanted_content_types.split(",")]
@@ -90,14 +89,14 @@ class Add(Sync):
                     self.add_status_message("Please enter a valid Prefix.",
                                             "error")
                     return self.template()
-
-                prefixable_types = [t.strip() for t in prefixable_types.split(",")]
+                prefixable_types = [t.strip() for t
+                                    in prefixable_types.split(",")]
                 prefixable_types = filter(lambda ct: ct in portal_types,
                                           prefixable_types)
 
             if prefix and not prefixable_types:
                 self.add_status_message("Please enter valid Content Types to be"
-                                        " prefixified.", "error")
+                                        " created with the Prefix.", "error")
                 return self.template()
 
             data = {

--- a/src/senaite/sync/browser/add.py
+++ b/src/senaite/sync/browser/add.py
@@ -12,7 +12,7 @@ from senaite.sync.fetchstep import FetchStep
 from zope.interface import implements
 
 SYNC_STORAGE = "senaite.sync"
-
+PREFIX_SPECIAL_CHARACTERS = u"*.!$%&/()=-+:'`´^"
 
 class Add(Sync):
     """ Add new sync instance view
@@ -69,7 +69,7 @@ class Add(Sync):
 
             # Prefix Validation
             if prefix:
-                prefix = prefix.strip(u"*.!$%&/()=-+:'`´^")
+                prefix = prefix.strip(PREFIX_SPECIAL_CHARACTERS)
                 if not prefix:
                     self.add_status_message("Invalid Prefix!", "error")
                     return self.template()
@@ -87,10 +87,11 @@ class Add(Sync):
                 portal_types = api.get_tool("portal_types")
                 prefixable_types = filter(lambda ct: ct in portal_types,
                                           prefixable_types)
-                if not prefixable_types:
-                    self.add_status_message("Invalid Content Types to be"
-                                            "Prefixified!", "error")
-                    return self.template()
+
+            if prefix and not prefixable_types:
+                self.add_status_message("Please enter valid Content Types to be"
+                                        " prefixified.", "error")
+                return self.template()
 
             data = {
                 "url": url,

--- a/src/senaite/sync/browser/configure.zcml
+++ b/src/senaite/sync/browser/configure.zcml
@@ -9,6 +9,13 @@
       permission="cmf.ManagePortal"
       />
 
+    <browser:page
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      name="sync_add"
+      class=".add.Add"
+      permission="cmf.ManagePortal"
+      />
+
   <browser:page
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       name="do_auto_sync"

--- a/src/senaite/sync/browser/templates/add.pt
+++ b/src/senaite/sync/browser/templates/add.pt
@@ -197,6 +197,28 @@
                     </div>
                   </li>
 
+                  <li class="list-group-item">
+                    <!-- Content Types to be prefixified -->
+                    <div class="field form-group field">
+                      <label i18n:translate=""
+                             class="form-control-label"
+                             for="prefixable_types">
+                        Prefixable Content Types
+                        <span i18n:translate=""
+                              class="help formHelp">
+                          Please specify exactly which content types must contain Remote's Prefix in their ID's. E.g: 'Sample, Client, Worksheet'
+                        </span>
+                      </label>
+                      <div class="form-group input-group">
+                        <input type="text"
+                               size="45"
+                               class="form-control"
+                               id="prefixable_types"
+                               name="prefixable_types"/>
+                      </div>
+                    </div>
+                  </li>
+
                 </ul>
               </div>
             </div>

--- a/src/senaite/sync/browser/templates/add.pt
+++ b/src/senaite/sync/browser/templates/add.pt
@@ -162,7 +162,7 @@
                         Content Types
                         <span i18n:translate=""
                               class="help formHelp">
-                          If filled, only indicated Content Types (separated by comma) will be imported. E.g: 'Sample, Client, Worksheet'
+                          If filled, ONLY indicated Content Types (separated by comma) will be imported. E.g: 'Sample, Client, Worksheet'
                         </span>
                       </label>
                       <div class="form-group input-group">
@@ -171,6 +171,28 @@
                                class="form-control"
                                id="content_types"
                                name="content_types"/>
+                      </div>
+                    </div>
+                  </li>
+
+                  <li class="list-group-item">
+                    <!-- Unwanted Content Types -->
+                    <div class="field form-group field">
+                      <label i18n:translate=""
+                             class="form-control-label"
+                             for="unwanted_content_types">
+                        Content Types to be Skipped
+                        <span i18n:translate=""
+                              class="help formHelp">
+                          If filled, introduced content types will be SKIPPED and only regular objects that are dependencies of the Allowed Types will be imported.. E.g: 'Supplier, Instrument'
+                        </span>
+                      </label>
+                      <div class="form-group input-group">
+                        <input type="text"
+                               size="45"
+                               class="form-control"
+                               id="unwanted_content_types"
+                               name="unwanted_content_types"/>
                       </div>
                     </div>
                   </li>
@@ -206,7 +228,7 @@
                         Prefixable Content Types
                         <span i18n:translate=""
                               class="help formHelp">
-                          Please specify exactly which content types must contain Remote's Prefix in their ID's. E.g: 'Sample, Client, Worksheet'
+                          Please specify exactly which content types must contain Remote's Prefix in their ID's. Must be filled if prefix is enabled. E.g: 'Sample, Client, Worksheet'
                         </span>
                       </label>
                       <div class="form-group input-group">

--- a/src/senaite/sync/browser/templates/add.pt
+++ b/src/senaite/sync/browser/templates/add.pt
@@ -1,0 +1,201 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="senaite">
+  <head>
+    <metal:block fill-slot="javascript_head_slot"
+                 tal:define="portal context/@@plone_portal_state/portal;">
+    </metal:block>
+  </head>
+  <body>
+
+    <metal:title fill-slot="content-title">
+      <h1 i18n:translate="">
+        Add new Remote
+      </h1>
+    </metal:title>
+    <metal:description fill-slot="content-description">
+      <p i18n:translate="">
+      </p>
+    </metal:description>
+
+    <div metal:fill-slot="content-core"
+         tal:define="portal context/@@plone_portal_state/portal;">
+
+      <form id="fetch_form"
+            name="fetch_form"
+            method="POST">
+
+        <input type="hidden" name="fetchform" value="1"/>
+        <span tal:replace="structure context/@@authenticator/authenticator"/>
+
+        <!-- Domain Name -->
+        <div class="field form-group field">
+          <label i18n:translate=""
+                 class="form-control-label"
+                 for="domain_name">
+            Domain Name
+            <span class="required"></span>
+            <span i18n:translate=""
+                  class="help formHelp">
+              Representative unique name for the source system.
+            </span>
+          </label>
+          <div class="form-group input-group">
+            <span class="input-group-addon"><i class="glyphicon glyphicon-link"></i></span>
+            <input type="text" size="30"
+                   class="form-control"
+                   id="domain_name"
+                   tal:attributes="value view/domain_name|nothing"
+                   name="domain_name"/>
+          </div>
+        </div>
+
+        <!-- Base URL -->
+        <div class="field form-group field">
+          <label i18n:translate=""
+                 class="form-control-label"
+                 for="url">
+            Source URL
+            <span class="required"></span>
+            <span i18n:translate=""
+                  class="help formHelp">
+              The base URL of the source system, e.g. http://localhost:1337/senaitelims
+            </span>
+          </label>
+          <div class="form-group input-group">
+            <span class="input-group-addon"><i class="glyphicon glyphicon-link"></i></span>
+            <input type="text" size="30"
+                   class="form-control"
+                   id="url"
+                   tal:attributes="value view/url|nothing"
+                   name="url"/>
+          </div>
+        </div>
+
+        <!-- Username -->
+        <div class="field form-group field">
+          <label i18n:translate=""
+                 class="form-control-label"
+                 for="ac_name">
+            Username
+            <span class="required"></span>
+            <span i18n:translate=""
+                  class="help formHelp">
+              The username to login into the source system
+            </span>
+          </label>
+          <div class="form-group input-group">
+            <span class="input-group-addon"><i class="glyphicon glyphicon-user"></i></span>
+            <input type="text"
+                   size="30"
+                   autocomplete="new-username"
+                   class="form-control"
+                   id="ac_name"
+                   tal:attributes="value view/username|nothing"
+                   name="ac_name"/>
+          </div>
+        </div>
+
+        <!-- Password -->
+        <div class="field form-group field">
+          <label i18n:translate=""
+                 class="form-control-label"
+                 for="ac_password">
+            Password
+            <span class="required"></span>
+            <span i18n:translate=""
+                  class="help formHelp">
+              The password to login into the source system
+            </span>
+          </label>
+          <div class="form-group input-group">
+            <span class="input-group-addon"><i class="glyphicon glyphicon-lock"></i></span>
+            <input type="password"
+                   autocomplete="new-password"
+                   size="30"
+                   class="form-control"
+                   id="ac_password"
+                   tal:attributes="value view/password|nothing"
+                   name="ac_password"/>
+          </div>
+        </div>
+
+        <!-- Import configuration -->
+        <div class="field form-group field">
+          <div class="panel-group">
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <h4 class="panel-title">
+                 <a data-toggle="collapse" href="#collapse1">Show import configuration</a>
+               </h4>
+              </div>
+              <div id="collapse1" class="panel-collapse collapse">
+                <ul class="list-group">
+                  <li class="list-group-item">
+                    <div>
+                      <input type="checkbox"
+                             name="import_settings"
+                             id="import_settings"/>
+	     	          <label for="import_settings">Import Settings</label>
+	                </div>
+                  </li>
+                  <li class="list-group-item">
+                    <div>
+                      <input type="checkbox"
+                             name="import_registry"
+                             id="import_registry"/>
+	     	          <label for="import_registry">Import Registry</label>
+	                </div>
+                  </li>
+                  <li class="list-group-item">
+                    <div>
+                      <input type="checkbox"
+                             name="import_users"
+                             id="import_users"/>
+	     	          <label for="import_users">Import Users</label>
+	                </div>
+                  </li>
+                  <li class="list-group-item">
+                    <!-- Content Types -->
+                    <div class="field form-group field">
+                      <label i18n:translate=""
+                             class="form-control-label"
+                             for="content_types">
+                        Content Types
+                        <span i18n:translate=""
+                              class="help formHelp">
+                          If filled, only indicated Content Types (separated by comma) will be imported. E.g: 'Sample, Client, Worksheet'
+                        </span>
+                      </label>
+                      <div class="form-group input-group">
+                        <input type="text"
+                               size="45"
+                               class="form-control"
+                               id="content_types"
+                               tal:attributes="value view/content_types|nothing"
+                               name="content_types"/>
+                      </div>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <input class="btn btn-success btn-sm allowMultiSubmit"
+               type="submit"
+               name="fetch"
+               i18n:attributes="value"
+               value="Save & Fetch"/>
+
+      </form><br><br>
+      <form action="sync">
+          <input type="submit" value="Show Remotes" />
+      </form>
+    </div>
+
+  </body>
+</html>

--- a/src/senaite/sync/browser/templates/add.pt
+++ b/src/senaite/sync/browser/templates/add.pt
@@ -251,7 +251,7 @@
                type="submit"
                name="fetch"
                i18n:attributes="value"
-               value="Save & Fetch"/>
+               value="Save and Fetch"/>
 
       </form><br><br>
       <form action="sync">

--- a/src/senaite/sync/browser/templates/add.pt
+++ b/src/senaite/sync/browser/templates/add.pt
@@ -47,7 +47,6 @@
             <input type="text" size="30"
                    class="form-control"
                    id="domain_name"
-                   tal:attributes="value view/domain_name|nothing"
                    name="domain_name"/>
           </div>
         </div>
@@ -69,7 +68,6 @@
             <input type="text" size="30"
                    class="form-control"
                    id="url"
-                   tal:attributes="value view/url|nothing"
                    name="url"/>
           </div>
         </div>
@@ -93,7 +91,6 @@
                    autocomplete="new-username"
                    class="form-control"
                    id="ac_name"
-                   tal:attributes="value view/username|nothing"
                    name="ac_name"/>
           </div>
         </div>
@@ -117,7 +114,6 @@
                    size="30"
                    class="form-control"
                    id="ac_password"
-                   tal:attributes="value view/password|nothing"
                    name="ac_password"/>
           </div>
         </div>
@@ -128,7 +124,7 @@
             <div class="panel panel-default">
               <div class="panel-heading">
                 <h4 class="panel-title">
-                 <a data-toggle="collapse" href="#collapse1">Show import configuration</a>
+                 <a data-toggle="collapse" href="#collapse1">Advanced Configuration</a>
                </h4>
               </div>
               <div id="collapse1" class="panel-collapse collapse">
@@ -174,11 +170,33 @@
                                size="45"
                                class="form-control"
                                id="content_types"
-                               tal:attributes="value view/content_types|nothing"
                                name="content_types"/>
                       </div>
                     </div>
                   </li>
+
+                  <li class="list-group-item">
+                    <!-- Prefix -->
+                    <div class="field form-group field">
+                      <label i18n:translate=""
+                             class="form-control-label"
+                             for="prefix">
+                        Prefix
+                        <span i18n:translate=""
+                              class="help formHelp">
+                          A short prefix to appear in the Object ID's imported from this Remote.
+                        </span>
+                      </label>
+                      <div class="form-group input-group">
+                        <input type="text"
+                               size="10"
+                               class="form-control"
+                               id="prefix"
+                               name="prefix"/>
+                      </div>
+                    </div>
+                  </li>
+
                 </ul>
               </div>
             </div>

--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -45,14 +45,14 @@
 
             <dd class="collapsibleContent">
               <div
-                      tal:define="content_types python:view.storage[storage]['configuration'].get('content_types');
-                                  unwanted_content_types python:view.storage[storage]['configuration'].get('unwanted_content_types');
-                                  prefixable_types python:view.storage[storage]['configuration'].get('prefixable_types');"
+                      tal:define="content_types python: view.get_storage_config(domain_name, 'content_types');
+                                  unwanted_content_types python: view.get_storage_config(domain_name, 'unwanted_content_types');
+                                  prefixable_types python: view.get_storage_config(domain_name, 'prefixable_types');"
               >
-                  <b>Prefix: <span style="font-size: medium" tal:replace="python: view.storage[storage]['configuration'].get('prefix', 'Not defined')"/></b><br><br>
-                  Settings will <span tal:condition="python: not view.storage[storage]['configuration'].get('import_settings')">NOT</span>,
-                  Registry will <span tal:condition="python: not view.storage[storage]['configuration'].get('import_registry')">NOT</span>,
-                  Users will <span tal:condition="python: not view.storage[storage]['configuration'].get('import_users')">NOT</span> be imported.<br><br>
+                  <b>Prefix: <span style="font-size: medium" tal:replace="python: view.get_storage_config(domain_name, 'prefix', 'Not Defined')"/></b><br><br>
+                  Settings will <span tal:condition="python: not view.get_storage_config(domain_name, 'import_settings')">NOT</span>,
+                  Registry will <span tal:condition="python: not view.get_storage_config(domain_name, 'import_registry')">NOT</span>,
+                  Users will <span tal:condition="python: not view.get_storage_config(domain_name, 'import_users')">NOT</span> be imported.<br><br>
 
                   Content types to be imported: <b><span tal:replace="python: ', '.join(content_types) if content_types else 'All the content types'"/> </b><br><br>
                   Content types to be skipped: <b><span tal:replace="python: ', '.join(unwanted_content_types) if unwanted_content_types else 'Not specified'"/> </b><br><br>

--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -43,14 +43,19 @@
             <input type="hidden" name="domain_name" value="" tal:attributes="value storage" />
 
             <dd class="collapsibleContent">
-              <div>
+              <div
+                      tal:define="content_types python:view.storage[storage]['configuration'].get('content_types');
+                                  unwanted_content_types python:view.storage[storage]['configuration'].get('unwanted_content_types');
+                                  prefixable_types python:view.storage[storage]['configuration'].get('prefixable_types');"
+              >
                   <b>Prefix: <span style="font-size: medium" tal:replace="python: view.storage[storage]['configuration'].get('prefix', 'Not defined')"/></b><br><br>
                   Settings will <span tal:condition="python: not view.storage[storage]['configuration'].get('import_settings')">NOT</span>,
                   Registry will <span tal:condition="python: not view.storage[storage]['configuration'].get('import_registry')">NOT</span>,
                   Users will <span tal:condition="python: not view.storage[storage]['configuration'].get('import_users')">NOT</span> be imported.<br><br>
-                  Content types to be imported: <b><span tal:replace="python: ', '.join(view.storage[storage]['configuration'].get('content_types', ['All the content types']))"/> </b><br><br>
-                  Content types to be skipped: <b><span tal:replace="python: ', '.join(view.storage[storage]['configuration'].get('unwanted_content_types', ['Not specified']))"/> </b><br><br>
-                  Content types that will contain prefix: <b><span tal:replace="python: ', '.join(view.storage[storage]['configuration'].get('prefixable_types', ['Not defined']))"/> </b><br><br>
+
+                  Content types to be imported: <b><span tal:replace="python: ', '.join(content_types) if content_types else 'All the content types'"/> </b><br><br>
+                  Content types to be skipped: <b><span tal:replace="python: ', '.join(unwanted_content_types) if unwanted_content_types else 'Not specified'"/> </b><br><br>
+                  Content types that will contain prefix: <b><span tal:replace="python: ', '.join(prefixable_types) if prefixable_types else 'Not defined'"/> </b><br><br>
               </div><br>
               <input class="btn btn-default btn-sm"
                      type="submit"

--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -45,14 +45,14 @@
 
             <dd class="collapsibleContent">
               <div
-                      tal:define="content_types python: view.get_storage_config(domain_name, 'content_types');
-                                  unwanted_content_types python: view.get_storage_config(domain_name, 'unwanted_content_types');
-                                  prefixable_types python: view.get_storage_config(domain_name, 'prefixable_types');"
+                      tal:define="content_types python: view.get_storage_config(storage, 'content_types');
+                                  unwanted_content_types python: view.get_storage_config(storage, 'unwanted_content_types');
+                                  prefixable_types python: view.get_storage_config(storage, 'prefixable_types');"
               >
-                  <b>Prefix: <span style="font-size: medium" tal:replace="python: view.get_storage_config(domain_name, 'prefix', 'Not Defined')"/></b><br><br>
-                  Settings will <span tal:condition="python: not view.get_storage_config(domain_name, 'import_settings')">NOT</span>,
-                  Registry will <span tal:condition="python: not view.get_storage_config(domain_name, 'import_registry')">NOT</span>,
-                  Users will <span tal:condition="python: not view.get_storage_config(domain_name, 'import_users')">NOT</span> be imported.<br><br>
+                  <b>Prefix: <span style="font-size: medium" tal:replace="python: view.get_storage_config(storage, 'prefix', 'Not Defined')"/></b><br><br>
+                  Settings will <span tal:condition="python: not view.get_storage_config(storage, 'import_settings')">NOT</span>,
+                  Registry will <span tal:condition="python: not view.get_storage_config(storage, 'import_registry')">NOT</span>,
+                  Users will <span tal:condition="python: not view.get_storage_config(storage, 'import_users')">NOT</span> be imported.<br><br>
 
                   Content types to be imported: <b><span tal:replace="python: ', '.join(content_types) if content_types else 'All the content types'"/> </b><br><br>
                   Content types to be skipped: <b><span tal:replace="python: ', '.join(unwanted_content_types) if unwanted_content_types else 'Not specified'"/> </b><br><br>

--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -44,9 +44,13 @@
 
             <dd class="collapsibleContent">
               <div>
-                  Import settings: <span tal:replace="python:view.storage[storage]['configuration'].get('import_settings')"/>
-                  Import registry: <span tal:replace="python:view.storage[storage]['configuration'].get('import_registry')"/>
-                  Import users: <span tal:replace="python:view.storage[storage]['configuration'].get('import_users')"/>
+                  <b>Prefix: <span style="font-size: medium" tal:replace="python: view.storage[storage]['configuration'].get('prefix', 'Not defined')"/></b><br><br>
+                  Settings will <span tal:condition="python: not view.storage[storage]['configuration'].get('import_settings')">NOT</span>,
+                  Registry will <span tal:condition="python: not view.storage[storage]['configuration'].get('import_registry')">NOT</span>,
+                  Users will <span tal:condition="python: not view.storage[storage]['configuration'].get('import_users')">NOT</span> be imported.<br><br>
+                  Content types to be imported: <b><span tal:replace="python: ', '.join(view.storage[storage]['configuration'].get('content_types', ['All the content types']))"/> </b><br><br>
+                  Content types to be skipped: <b><span tal:replace="python: ', '.join(view.storage[storage]['configuration'].get('unwanted_content_types', ['Not specified']))"/> </b><br><br>
+                  Content types that will contain prefix: <b><span tal:replace="python: ', '.join(view.storage[storage]['configuration'].get('prefixable_types', ['Not defined']))"/> </b><br><br>
               </div><br>
               <input class="btn btn-default btn-sm"
                      type="submit"

--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -12,7 +12,7 @@
 
     <metal:title fill-slot="content-title">
       <h1 i18n:translate="">
-        SENAITE SYNC
+        SENAITE SYNC REMOTES
       </h1>
     </metal:title>
     <metal:description fill-slot="content-description">
@@ -23,175 +23,9 @@
     <div metal:fill-slot="content-core"
          tal:define="portal context/@@plone_portal_state/portal;">
 
-      <form id="fetch_form"
-            name="fetch_form"
-            method="POST">
-
-        <input type="hidden" name="fetchform" value="1"/>
-        <span tal:replace="structure context/@@authenticator/authenticator"/>
-
-        <!-- Domain Name -->
-        <div class="field form-group field">
-          <label i18n:translate=""
-                 class="form-control-label"
-                 for="domain_name">
-            Domain Name
-            <span class="required"></span>
-            <span i18n:translate=""
-                  class="help formHelp">
-              Representative unique name for the source system.
-            </span>
-          </label>
-          <div class="form-group input-group">
-            <span class="input-group-addon"><i class="glyphicon glyphicon-link"></i></span>
-            <input type="text" size="30"
-                   class="form-control"
-                   id="domain_name"
-                   tal:attributes="value view/domain_name|nothing"
-                   name="domain_name"/>
-          </div>
-        </div>
-
-        <!-- Base URL -->
-        <div class="field form-group field">
-          <label i18n:translate=""
-                 class="form-control-label"
-                 for="url">
-            Source URL
-            <span class="required"></span>
-            <span i18n:translate=""
-                  class="help formHelp">
-              The base URL of the source system, e.g. http://localhost:1337/senaitelims
-            </span>
-          </label>
-          <div class="form-group input-group">
-            <span class="input-group-addon"><i class="glyphicon glyphicon-link"></i></span>
-            <input type="text" size="30"
-                   class="form-control"
-                   id="url"
-                   tal:attributes="value view/url|nothing"
-                   name="url"/>
-          </div>
-        </div>
-
-        <!-- Username -->
-        <div class="field form-group field">
-          <label i18n:translate=""
-                 class="form-control-label"
-                 for="ac_name">
-            Username
-            <span class="required"></span>
-            <span i18n:translate=""
-                  class="help formHelp">
-              The username to login into the source system
-            </span>
-          </label>
-          <div class="form-group input-group">
-            <span class="input-group-addon"><i class="glyphicon glyphicon-user"></i></span>
-            <input type="text"
-                   size="30"
-                   autocomplete="new-username"
-                   class="form-control"
-                   id="ac_name"
-                   tal:attributes="value view/username|nothing"
-                   name="ac_name"/>
-          </div>
-        </div>
-
-        <!-- Password -->
-        <div class="field form-group field">
-          <label i18n:translate=""
-                 class="form-control-label"
-                 for="ac_password">
-            Password
-            <span class="required"></span>
-            <span i18n:translate=""
-                  class="help formHelp">
-              The password to login into the source system
-            </span>
-          </label>
-          <div class="form-group input-group">
-            <span class="input-group-addon"><i class="glyphicon glyphicon-lock"></i></span>
-            <input type="password"
-                   autocomplete="new-password"
-                   size="30"
-                   class="form-control"
-                   id="ac_password"
-                   tal:attributes="value view/password|nothing"
-                   name="ac_password"/>
-          </div>
-        </div>
-
-        <!-- Import configuration -->
-        <div class="field form-group field">
-          <div class="panel-group">
-            <div class="panel panel-default">
-              <div class="panel-heading">
-                <h4 class="panel-title">
-                 <a data-toggle="collapse" href="#collapse1">Show import configuration</a>
-               </h4>
-              </div>
-              <div id="collapse1" class="panel-collapse collapse">
-                <ul class="list-group">
-                  <li class="list-group-item">
-                    <div>
-                      <input type="checkbox"
-                             name="import_settings"
-                             id="import_settings"/>
-	     	          <label for="import_settings">Import Settings</label>
-	                </div>
-                  </li>
-                  <li class="list-group-item">
-                    <div>
-                      <input type="checkbox"
-                             name="import_registry"
-                             id="import_registry"/>
-	     	          <label for="import_registry">Import Registry</label>
-	                </div>
-                  </li>
-                  <li class="list-group-item">
-                    <div>
-                      <input type="checkbox"
-                             name="import_users"
-                             id="import_users"/>
-	     	          <label for="import_users">Import Users</label>
-	                </div>
-                  </li>
-                  <li class="list-group-item">
-                    <!-- Content Types -->
-                    <div class="field form-group field">
-                      <label i18n:translate=""
-                             class="form-control-label"
-                             for="content_types">
-                        Content Types
-                        <span i18n:translate=""
-                              class="help formHelp">
-                          If filled, only indicated Content Types (separated by comma) will be imported. E.g: 'Sample, Client, Worksheet'
-                        </span>
-                      </label>
-                      <div class="form-group input-group">
-                        <input type="text"
-                               size="45"
-                               class="form-control"
-                               id="content_types"
-                               tal:attributes="value view/content_types|nothing"
-                               name="content_types"/>
-                      </div>
-                    </div>
-                  </li>
-                </ul>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <input class="btn btn-success btn-sm allowMultiSubmit"
-               type="submit"
-               name="fetch"
-               i18n:attributes="value"
-               value="Fetch"/>
-
-      </form>
+      <form action="sync_add">
+        <input type="submit" value="Add New Remote" />
+      </form><br><br>
 
       <!-- Storage View -->
       <tal:storage repeat="storage view/storage">
@@ -202,7 +36,7 @@
           <dl class="collapsible">
 
             <dt class="collapsibleHeader">
-              Data for <span tal:replace="storage"/>
+              <span tal:replace="storage"/>
               (<span tal:replace="python:len(view.storage[storage]['ordered_uids'])"/> Items)
             </dt>
             <input type="hidden" name="dataform" value="1"/>
@@ -229,7 +63,7 @@
               <div>
                   <dl class="collapsible">
                       <dt class="collapsibleHeader">
-                          Complement Step
+                          Run Complement Step
                       </dt>
                       <dd class="collapsibleContent">
                           <div class="field form-group field">

--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -29,6 +29,7 @@
 
       <!-- Storage View -->
       <tal:storage repeat="storage view/storage">
+        <div style="border:double; padding:10px">
         <form
           name="data_form"
           method="POST">
@@ -36,7 +37,7 @@
           <dl class="collapsible">
 
             <dt class="collapsibleHeader">
-              <span tal:replace="storage"/>
+              <span tal:replace="python: storage.upper()"/>
               (<span tal:replace="python:len(view.storage[storage]['ordered_uids'])"/> Items)
             </dt>
             <input type="hidden" name="dataform" value="1"/>
@@ -69,10 +70,10 @@
                      name="clear_storage"
                      i18n:attributes="value"
                      value="Clear this Storage"/>
-              <div>
+              <div style="margin-top: 15px">
                   <dl class="collapsible">
                       <dt class="collapsibleHeader">
-                          Run Complement Step
+                          RUN COMPLEMENT STEP
                       </dt>
                       <dd class="collapsibleContent">
                           <div class="field form-group field">
@@ -104,6 +105,7 @@
             </dd>
           </dl>
         </form>
+      </div>
       </tal:storage>
 
     </div>

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -67,6 +67,7 @@ class Sync(BrowserView):
             password = storage["credentials"]["password"]
             content_types = storage["configuration"].get("content_types", None)
             prefix = storage["configuration"].get("prefix", None)
+            prefixable_types = storage["configuration"].get("prefixable_types", None)
             data = {
                 "url": url,
                 "domain_name": domain_name,
@@ -74,6 +75,7 @@ class Sync(BrowserView):
                 "ac_password": password,
                 "content_types": content_types,
                 "prefix": prefix,
+                "prefixable_types": prefixable_types,
             }
             step = ImportStep(data)
             step.run()
@@ -104,6 +106,7 @@ class Sync(BrowserView):
             password = storage["credentials"]["password"]
             content_types = storage["configuration"].get("content_types", None)
             prefix = storage["configuration"].get("prefix", None)
+            prefixable_types = storage["configuration"].get("prefixable_types", None)
             data = {
                 "url": url,
                 "domain_name": domain_name,
@@ -112,6 +115,7 @@ class Sync(BrowserView):
                 "fetch_time": fetch_time,
                 "content_types": content_types,
                 "prefix": prefix,
+                "prefixable_types": prefixable_types,
             }
             step = ComplementStep(data)
             step.run()

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -65,10 +65,10 @@ class Sync(BrowserView):
             url = storage["credentials"]["url"]
             username = storage["credentials"]["username"]
             password = storage["credentials"]["password"]
-            content_types = storage["configuration"].get("content_types", None)
-            unwanted_content_types = storage["configuration"].get("unwanted_content_types", None)
+            content_types = storage["configuration"].get("content_types", [])
+            unwanted_content_types = storage["configuration"].get("unwanted_content_types", [])
             prefix = storage["configuration"].get("prefix", None)
-            prefixable_types = storage["configuration"].get("prefixable_types", None)
+            prefixable_types = storage["configuration"].get("prefixable_types", [])
             data = {
                 "url": url,
                 "domain_name": domain_name,
@@ -106,10 +106,10 @@ class Sync(BrowserView):
             url = storage["credentials"]["url"]
             username = storage["credentials"]["username"]
             password = storage["credentials"]["password"]
-            content_types = storage["configuration"].get("content_types", None)
-            unwanted_content_types = storage["configuration"].get("unwanted_content_types", None)
+            content_types = storage["configuration"].get("content_types", [])
+            unwanted_content_types = storage["configuration"].get("unwanted_content_types", [])
             prefix = storage["configuration"].get("prefix", None)
-            prefixable_types = storage["configuration"].get("prefixable_types", None)
+            prefixable_types = storage["configuration"].get("prefixable_types", [])
             data = {
                 "url": url,
                 "domain_name": domain_name,

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -66,6 +66,7 @@ class Sync(BrowserView):
             username = storage["credentials"]["username"]
             password = storage["credentials"]["password"]
             content_types = storage["configuration"].get("content_types", None)
+            unwanted_content_types = storage["configuration"].get("unwanted_content_types", None)
             prefix = storage["configuration"].get("prefix", None)
             prefixable_types = storage["configuration"].get("prefixable_types", None)
             data = {
@@ -74,6 +75,7 @@ class Sync(BrowserView):
                 "ac_name": username,
                 "ac_password": password,
                 "content_types": content_types,
+                "unwanted_content_types": unwanted_content_types,
                 "prefix": prefix,
                 "prefixable_types": prefixable_types,
             }
@@ -105,6 +107,7 @@ class Sync(BrowserView):
             username = storage["credentials"]["username"]
             password = storage["credentials"]["password"]
             content_types = storage["configuration"].get("content_types", None)
+            unwanted_content_types = storage["configuration"].get("unwanted_content_types", None)
             prefix = storage["configuration"].get("prefix", None)
             prefixable_types = storage["configuration"].get("prefixable_types", None)
             data = {
@@ -114,6 +117,7 @@ class Sync(BrowserView):
                 "ac_password": password,
                 "fetch_time": fetch_time,
                 "content_types": content_types,
+                "unwanted_content_types": unwanted_content_types,
                 "prefix": prefix,
                 "prefixable_types": prefixable_types,
             }

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -65,10 +65,14 @@ class Sync(BrowserView):
             url = storage["credentials"]["url"]
             username = storage["credentials"]["username"]
             password = storage["credentials"]["password"]
-            content_types = storage["configuration"].get("content_types", [])
-            unwanted_content_types = storage["configuration"].get("unwanted_content_types", [])
-            prefix = storage["configuration"].get("prefix", None)
-            prefixable_types = storage["configuration"].get("prefixable_types", [])
+            prefix = self.get_storage_config(domain_name, "prefix", None)
+            content_types = self.get_storage_config(
+                                    domain_name, "content_types", [])
+            unwanted_content_types = self.get_storage_config(
+                                    domain_name, "unwanted_content_types", [])
+            prefixable_types = self.get_storage_config(
+                                    domain_name, "prefixable_types", [])
+
             data = {
                 "url": url,
                 "domain_name": domain_name,
@@ -106,10 +110,14 @@ class Sync(BrowserView):
             url = storage["credentials"]["url"]
             username = storage["credentials"]["username"]
             password = storage["credentials"]["password"]
-            content_types = storage["configuration"].get("content_types", [])
-            unwanted_content_types = storage["configuration"].get("unwanted_content_types", [])
-            prefix = storage["configuration"].get("prefix", None)
-            prefixable_types = storage["configuration"].get("prefixable_types", [])
+            prefix = self.get_storage_config(domain_name, "prefix", None)
+            content_types = self.get_storage_config(
+                                    domain_name, "content_types", [])
+            unwanted_content_types = self.get_storage_config(
+                                    domain_name, "unwanted_content_types", [])
+            prefixable_types = self.get_storage_config(
+                                    domain_name, "prefixable_types", [])
+
             data = {
                 "url": url,
                 "domain_name": domain_name,
@@ -136,6 +144,15 @@ class Sync(BrowserView):
 
         # always render the template
         return self.template()
+
+    def get_storage_config(self, domain_name, config_name, default = None):
+        """ Get the advanced configuration setting for a given domain
+        :param config_name: advanced configuration section name
+        :param default: default value if configuration value is not set
+        :return:
+        """
+        storage = self.get_storage(domain_name)
+        return storage["configuration"].get(config_name, default)
 
     def add_status_message(self, message, level="info"):
         """Set a portal status message

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -66,12 +66,14 @@ class Sync(BrowserView):
             username = storage["credentials"]["username"]
             password = storage["credentials"]["password"]
             content_types = storage["configuration"].get("content_types", None)
+            prefix = storage["configuration"].get("prefix", None)
             data = {
                 "url": url,
                 "domain_name": domain_name,
                 "ac_name": username,
                 "ac_password": password,
                 "content_types": content_types,
+                "prefix": prefix,
             }
             step = ImportStep(data)
             step.run()
@@ -101,6 +103,7 @@ class Sync(BrowserView):
             username = storage["credentials"]["username"]
             password = storage["credentials"]["password"]
             content_types = storage["configuration"].get("content_types", None)
+            prefix = storage["configuration"].get("prefix", None)
             data = {
                 "url": url,
                 "domain_name": domain_name,
@@ -108,6 +111,7 @@ class Sync(BrowserView):
                 "ac_password": password,
                 "fetch_time": fetch_time,
                 "content_types": content_types,
+                "prefix": prefix,
             }
             step = ComplementStep(data)
             step.run()

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -122,50 +122,6 @@ class Sync(BrowserView):
             self.add_status_message(message, "info")
             return self.template()
 
-        # Handle "Fetch" action
-        if form.get("fetch", False):
-
-            url = form.get("url", "")
-            if not url.startswith("http"):
-                url = "http://{}".format(url)
-            domain_name = form.get("domain_name", None)
-            username = form.get("ac_name", None)
-            password = form.get("ac_password", None)
-            # check if all mandatory fields have values
-            if not all([domain_name, url, username, password]):
-                message = _("Please fill in all required fields")
-                self.add_status_message(message, "error")
-                return self.template()
-
-            import_settings = True if form.get("import_settings") == 'on' else False
-            import_users = True if form.get("import_users") == 'on' else False
-            import_registry = True if form.get("import_registry") == 'on' else False
-            content_types = form.get("content_types", None)
-            if content_types is not None:
-                content_types = [t.strip() for t in content_types.split(",")]
-                portal_types = api.get_tool("portal_types")
-                content_types = filter(lambda ct: ct in portal_types,
-                                       content_types)
-
-            data = {
-                "url": url,
-                "domain_name": domain_name,
-                "ac_name": username,
-                "ac_password": password,
-                "content_types": content_types,
-                "import_settings": import_settings,
-                "import_users": import_users,
-                "import_registry": import_registry,
-            }
-
-            fs = FetchStep(data)
-            verified, message = fs.verify()
-            if verified:
-                fs.run()
-                self.add_status_message(message, "info")
-            else:
-                self.add_status_message(message, "error")
-
         # always render the template
         return self.template()
 

--- a/src/senaite/sync/complementstep.py
+++ b/src/senaite/sync/complementstep.py
@@ -71,7 +71,7 @@ class ComplementStep(ImportStep):
 
             for item in items:
                 # skip object or extract the required data for the import
-                if not item or not item.get("portal_type", True):
+                if not self.is_item_allowed(item):
                     continue
                 modified = DateTime(item.get('modification_date'))
                 if modified < self.fetch_time:

--- a/src/senaite/sync/complementstep.py
+++ b/src/senaite/sync/complementstep.py
@@ -9,7 +9,8 @@ from senaite import api
 from senaite.sync.importstep import ImportStep
 
 from senaite.sync import logger, utils
-from senaite.sync.souphandler import SoupHandler, REMOTE_UID, LOCAL_UID
+from senaite.sync.souphandler import SoupHandler, REMOTE_UID, LOCAL_UID, \
+                                     REMOTE_PATH
 
 
 class ComplementStep(ImportStep):
@@ -82,8 +83,8 @@ class ComplementStep(ImportStep):
                 # If remote UID is in the souper table already, just check if
                 # remote path of the object has been updated
                 if existing_rec:
-                    rem_path = data_dict.get('path')
-                    if rem_path != existing_rec.get('path'):
+                    rem_path = data_dict.get(REMOTE_PATH)
+                    if rem_path != existing_rec.get(REMOTE_PATH):
                         self.sh.update_by_remote_uid(**data_dict)
                     rec_id = existing_rec.get("rec_int_id")
                 else:
@@ -122,7 +123,7 @@ class ComplementStep(ImportStep):
             row = self.sh.get_record_by_id(rec_id, as_dict=True)
             if not row:
                 continue
-            logger.debug("Handling: {} ".format(row["path"]))
+            logger.debug("Handling: {} ".format(row[REMOTE_PATH]))
             self._handle_obj(row, handle_dependencies=False)
 
             # Log.info every 50 objects imported

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -64,6 +64,7 @@ class FetchStep(SyncStep):
         storage["credentials"]["password"] = self.password
         # remember import configuration in the storage
         storage["configuration"]["content_types"] = self.content_types
+        storage["configuration"]["unwanted_content_types"] = self.unwanted_content_types
         storage["configuration"]["prefix"] = self.prefix
         storage["configuration"]["prefixable_types"] = self.prefixable_types
         storage["configuration"]["import_settings"] = self.import_settings
@@ -125,7 +126,10 @@ class FetchStep(SyncStep):
                     start_from, start_from+window))
             for item in items:
                 # skip object or extract the required data for the import
-                if not item or not item.get("portal_type", True):
+                if not item:
+                    continue
+                portal_type = item.get("portal_type", None)
+                if not portal_type or portal_type in self.unwanted_content_types:
                     continue
                 data_dict = utils.get_soup_format(item)
                 rec_id = self.sh.insert(data_dict)

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -64,6 +64,7 @@ class FetchStep(SyncStep):
         storage["credentials"]["password"] = self.password
         # remember import configuration in the storage
         storage["configuration"]["content_types"] = self.content_types
+        storage["configuration"]["prefix"] = self.prefix
         storage["configuration"]["import_settings"] = self.import_settings
         storage["configuration"]["import_registry"] = self.import_registry
         storage["configuration"]["import_users"] = self.import_users

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -126,10 +126,7 @@ class FetchStep(SyncStep):
                     start_from, start_from+window))
             for item in items:
                 # skip object or extract the required data for the import
-                if not item:
-                    continue
-                portal_type = item.get("portal_type", None)
-                if not portal_type or portal_type in self.unwanted_content_types:
+                if not self.is_item_allowed(item):
                     continue
                 data_dict = utils.get_soup_format(item)
                 rec_id = self.sh.insert(data_dict)

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -65,6 +65,7 @@ class FetchStep(SyncStep):
         # remember import configuration in the storage
         storage["configuration"]["content_types"] = self.content_types
         storage["configuration"]["prefix"] = self.prefix
+        storage["configuration"]["prefixable_types"] = self.prefixable_types
         storage["configuration"]["import_settings"] = self.import_settings
         storage["configuration"]["import_registry"] = self.import_registry
         storage["configuration"]["import_users"] = self.import_users

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -69,7 +69,7 @@ class FetchStep(SyncStep):
         storage["configuration"]["import_users"] = self.import_users
         storage["last_fetch_time"] = DateTime()
 
-        message = "Fetching Data started for {}".format(self.domain_name)
+        message = "Data fetched and saved: {}".format(self.domain_name)
         return True, message
 
     def get_version(self):

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -269,24 +269,24 @@ class ImportStep(SyncStep):
         :type row: dict
         """
         r_uid = row.get(REMOTE_UID)
-        try:
-            if row.get("updated", "0") == "1":
-                return True
-            self._queue.append(r_uid)
-            obj = self._do_obj_creation(row)
-            if obj is None:
-                logger.error('Object creation failed: {}'.format(row))
-                return
-            obj_data = self.get_json(r_uid, complete=True,
-                                     workflow=True)
-            if handle_dependencies:
-                self._create_dependencies(obj, obj_data)
-            self._update_object_with_data(obj, obj_data)
-            self.sh.mark_update(r_uid)
-            self._queue.remove(r_uid)
-        except Exception, e:
-            self._queue.remove(r_uid)
-            logger.error('Failed to handle {} : {} '.format(row, str(e)))
+        # try:
+        if row.get("updated", "0") == "1":
+            return True
+        self._queue.append(r_uid)
+        obj = self._do_obj_creation(row)
+        if obj is None:
+            logger.error('Object creation failed: {}'.format(row))
+            return
+        obj_data = self.get_json(r_uid, complete=True,
+                                 workflow=True)
+        if handle_dependencies:
+            self._create_dependencies(obj, obj_data)
+        self._update_object_with_data(obj, obj_data)
+        self.sh.mark_update(r_uid)
+        self._queue.remove(r_uid)
+        # except Exception, e:
+        #     self._queue.remove(r_uid)
+        #     logger.error('Failed to handle {} : {} '.format(row, str(e)))
 
         return True
 
@@ -307,7 +307,7 @@ class ImportStep(SyncStep):
             logger.warning("Parent creation failed previously, skipping: {}"
                            .format(remote_path))
             return None
-
+        import pdb; pdb.set_trace()
         local_path = self.translate_path(remote_path)
         existing = self.portal.unrestrictedTraverse(local_path, None)
         if existing:

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -307,7 +307,7 @@ class ImportStep(SyncStep):
             logger.warning("Parent creation failed previously, skipping: {}"
                            .format(remote_path))
             return None
-        import pdb; pdb.set_trace()
+
         local_path = self.translate_path(remote_path)
         existing = self.portal.unrestrictedTraverse(local_path, None)
         if existing:

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -308,7 +308,7 @@ class ImportStep(SyncStep):
                            .format(remote_path))
             return None
 
-        local_path = self.translate_path_with_prefix(remote_path)
+        local_path = self.translate_path(remote_path)
         existing = self.portal.unrestrictedTraverse(local_path, None)
         if existing:
             local_uid = self.sh.find_unique(REMOTE_PATH, remote_path).get(LOCAL_UID,
@@ -349,7 +349,7 @@ class ImportStep(SyncStep):
             return True
 
         # Incoming path was remote path, translate it into local one
-        local_p_path = self.translate_path_with_prefix(p_path)
+        local_p_path = self.translate_path(p_path)
 
         # Check if the parent already exists. If yes, make sure it has
         # 'local_uid' value set in the soup table.

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -374,7 +374,7 @@ class ImportStep(SyncStep):
         grand_parent = utils.get_parent_path(local_p_path)
         container = self.portal.unrestrictedTraverse(grand_parent, None)
         parent_data = {
-            "id": utils.get_id_from_path(p_path),
+            "id": utils.get_id_from_path(local_p_path),
             "remote_path": p_path,
             "portal_type": parent.get(PORTAL_TYPE)}
 

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -428,7 +428,7 @@ class ImportStep(SyncStep):
                     logger.error("Remote UID not found in fetched data: {}".
                                  format(r_uid))
                     continue
-                if not utils.is_item_allowed(dep_item):
+                if not utils.has_valid_portal_type(dep_item):
                     logger.error("Skipping dependency with unknown portal type:"
                                  " {}".format(dep_item))
                     continue

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -269,24 +269,24 @@ class ImportStep(SyncStep):
         :type row: dict
         """
         r_uid = row.get(REMOTE_UID)
-        # try:
-        if row.get("updated", "0") == "1":
-            return True
-        self._queue.append(r_uid)
-        obj = self._do_obj_creation(row)
-        if obj is None:
-            logger.error('Object creation failed: {}'.format(row))
-            return
-        obj_data = self.get_json(r_uid, complete=True,
-                                 workflow=True)
-        if handle_dependencies:
-            self._create_dependencies(obj, obj_data)
-        self._update_object_with_data(obj, obj_data)
-        self.sh.mark_update(r_uid)
-        self._queue.remove(r_uid)
-        # except Exception, e:
-        #     self._queue.remove(r_uid)
-        #     logger.error('Failed to handle {} : {} '.format(row, str(e)))
+        try:
+            if row.get("updated", "0") == "1":
+                return True
+            self._queue.append(r_uid)
+            obj = self._do_obj_creation(row)
+            if obj is None:
+                logger.error('Object creation failed: {}'.format(row))
+                return
+            obj_data = self.get_json(r_uid, complete=True,
+                                     workflow=True)
+            if handle_dependencies:
+                self._create_dependencies(obj, obj_data)
+            self._update_object_with_data(obj, obj_data)
+            self.sh.mark_update(r_uid)
+            self._queue.remove(r_uid)
+        except Exception, e:
+            self._queue.remove(r_uid)
+            logger.error('Failed to handle {} : {} '.format(row, str(e)))
 
         return True
 

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -361,6 +361,7 @@ class ImportStep(SyncStep):
                 return False
             p_local_uid = p_row.get(LOCAL_UID, None)
             if not p_local_uid:
+                # Update parent's local path if it is not set already
                 if hasattr(existing, "UID") and existing.UID():
                     p_local_uid = existing.UID()
                     self.sh.update_by_remote_path(p_path, local_uid=p_local_uid)

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -60,7 +60,8 @@ class ImportStep(SyncStep):
     update objects based on previously fetched data.
 
     """
-    fields_to_skip = ['excludeFromNav', 'constrainTypesMode', 'allowDiscussion']
+    fields_to_skip = ['id',  # Overriding ID's can remove prefixes
+                      'excludeFromNav', 'constrainTypesMode', 'allowDiscussion']
 
     def __init__(self, data):
         SyncStep.__init__(self, data)

--- a/src/senaite/sync/souphandler.py
+++ b/src/senaite/sync/souphandler.py
@@ -1,5 +1,4 @@
 
-
 from senaite import api
 from senaite.sync import logger
 
@@ -66,9 +65,10 @@ class SoupHandler:
             return False
         record = Record()
         record.attrs[REMOTE_UID] = data[REMOTE_UID]
-        record.attrs['path'] = data['path']
-        record.attrs[PORTAL_TYPE] = data[PORTAL_TYPE]
         record.attrs[LOCAL_UID] = data.get(LOCAL_UID, "")
+        record.attrs[REMOTE_PATH] = data[REMOTE_PATH]
+        record.attrs[LOCAL_PATH] = data[LOCAL_PATH]
+        record.attrs[PORTAL_TYPE] = data[PORTAL_TYPE]
         record.attrs[UPDATED] = data.get(UPDATED, "0")
         r_id = self.soup.add(record)
         logger.info("Record {} inserted: {}".format(r_id, data))
@@ -82,11 +82,13 @@ class SoupHandler:
         """
         r_uid = data.get(REMOTE_UID, False) or '-1'
         l_uid = data.get(LOCAL_UID, False) or '-1'
-        path = data.get("path", False) or '-1'
+        r_path = data.get(REMOTE_PATH, False) or '-1'
+        l_path = data.get(LOCAL_PATH, False) or '-1'
         r_uid_q = Eq(REMOTE_UID, r_uid)
         l_uid_q = Eq(LOCAL_UID, l_uid)
-        p_q = Eq('path', path)
-        ret = [r for r in self.soup.query(Or(r_uid_q, l_uid_q, p_q))]
+        r_p_q = Eq(REMOTE_PATH, r_path)
+        l_p_q = Eq(REMOTE_PATH, l_path)
+        ret = [r for r in self.soup.query(Or(r_uid_q, l_uid_q, r_p_q, l_p_q))]
         return ret != []
 
     def get_record_by_id(self, rec_id, as_dict=False):
@@ -137,16 +139,16 @@ class SoupHandler:
         self.soup.reindex([recs[0]])
         return True
 
-    def update_by_path(self, path, **kwargs):
+    def update_by_remote_path(self, remote_path, **kwargs):
         """
         Update the row by path column.
         :param path: path of the record
         :param kwargs: columns and their values to be updated.
         """
-        recs = [r for r in self.soup.query(Eq('path', path))]
+        recs = [r for r in self.soup.query(Eq(REMOTE_PATH, remote_path))]
         if not recs:
             logger.error("Could not find any record with path: '{}'"
-                         .format(path))
+                         .format(REMOTE_PATH))
             return False
         for k, v in kwargs.iteritems():
             recs[0].attrs[k] = v
@@ -174,7 +176,7 @@ class SoupHandler:
         for intid in self.soup.data:
             rec = self.soup.get(intid)
             rec.attrs[UPDATED] = "0"
-            self.soup.reindex(rec)
+        self.soup.reindex()
         return True
 
     def _create_domain_catalog(self):
@@ -187,11 +189,17 @@ class SoupHandler:
             def __call__(self, context=None):
                 catalog = Catalog()
                 r_uid_indexer = NodeAttributeIndexer(REMOTE_UID)
-                catalog[u'remote_uid'] = CatalogFieldIndex(r_uid_indexer)
-                path_indexer = NodeAttributeIndexer('path')
-                catalog[u'path'] = CatalogFieldIndex(path_indexer)
+                catalog[unicode(REMOTE_UID)] = CatalogFieldIndex(r_uid_indexer)
+
                 l_uid_indexer = NodeAttributeIndexer(LOCAL_UID)
-                catalog[u'local_uid'] = CatalogFieldIndex(l_uid_indexer)
+                catalog[unicode(LOCAL_UID)] = CatalogFieldIndex(l_uid_indexer)
+
+                r_path_indexer = NodeAttributeIndexer(REMOTE_PATH)
+                catalog[unicode(REMOTE_PATH)] = CatalogFieldIndex(r_path_indexer)
+
+                l_path_indexer = NodeAttributeIndexer(LOCAL_PATH)
+                catalog[unicode(LOCAL_PATH)] = CatalogFieldIndex(l_path_indexer)
+
                 return catalog
 
         provideUtility(DomainSoupCatalogFactory(), name=self.domain_name)
@@ -226,7 +234,8 @@ def record_to_dict(record):
         'rec_int_id': record.intid,
         REMOTE_UID: record.attrs.get(REMOTE_UID, ""),
         LOCAL_UID: record.attrs.get(LOCAL_UID, ""),
-        'path': record.attrs.get('path', ""),
+        REMOTE_PATH: record.attrs.get(REMOTE_PATH, ""),
+        LOCAL_PATH: record.attrs.get(LOCAL_PATH, ""),
         UPDATED: record.attrs.get(UPDATED, "0"),
         PORTAL_TYPE: record.attrs.get(PORTAL_TYPE, "")
     }

--- a/src/senaite/sync/souphandler.py
+++ b/src/senaite/sync/souphandler.py
@@ -87,7 +87,7 @@ class SoupHandler:
         r_uid_q = Eq(REMOTE_UID, r_uid)
         l_uid_q = Eq(LOCAL_UID, l_uid)
         r_p_q = Eq(REMOTE_PATH, r_path)
-        l_p_q = Eq(REMOTE_PATH, l_path)
+        l_p_q = Eq(LOCAL_PATH, l_path)
         ret = [r for r in self.soup.query(Or(r_uid_q, l_uid_q, r_p_q, l_p_q))]
         return ret != []
 

--- a/src/senaite/sync/souphandler.py
+++ b/src/senaite/sync/souphandler.py
@@ -67,7 +67,7 @@ class SoupHandler:
         record.attrs[REMOTE_UID] = data[REMOTE_UID]
         record.attrs[LOCAL_UID] = data.get(LOCAL_UID, "")
         record.attrs[REMOTE_PATH] = data[REMOTE_PATH]
-        record.attrs[LOCAL_PATH] = data[LOCAL_PATH]
+        record.attrs[LOCAL_PATH] = data.get(LOCAL_PATH, "")
         record.attrs[PORTAL_TYPE] = data[PORTAL_TYPE]
         record.attrs[UPDATED] = data.get(UPDATED, "0")
         r_id = self.soup.add(record)

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -43,10 +43,10 @@ class SyncStep(object):
         self.username = data.get("ac_name", None)
         self.password = data.get("ac_password", None)
         # Import configuration
-        self.content_types = data.get("content_types", None)
-        self.unwanted_content_types = data.get("unwanted_content_types", None)
+        self.content_types = data.get("content_types", [])
+        self.unwanted_content_types = data.get("unwanted_content_types", [])
         self.prefix = data.get("prefix", None)
-        self.prefixable_types = data.get("prefixable_types", None)
+        self.prefixable_types = data.get("prefixable_types", [])
         self.import_settings = data.get("import_settings", False)
         self.import_users = data.get("import_users", False)
         self.import_registry = data.get("import_registry", False)
@@ -266,7 +266,7 @@ class SyncStep(object):
         :return: True if ALL parents are fetched
         """
         # Never fetch parents of an unnecessary objects
-        if not utils.is_item_allowed(item):
+        if not utils.has_valid_portal_type(item):
             return False
         parent_path = item.get("parent_path")
         # Skip if the parent is portal object
@@ -281,3 +281,14 @@ class SyncStep(object):
         self.sh.insert(par_dict)
         # Recursively import grand parents too
         return self._parents_fetched(parent)
+
+    def is_item_allowed(self, item):
+        """ Checks if item is allowed based on its portal_type
+        :param item: object data dict
+        """
+        if not utils.has_valid_portal_type(item):
+            return False
+        if item.get("portal_type") in self.unwanted_content_types:
+            return False
+
+        return True

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -62,6 +62,10 @@ class SyncStep(object):
         :param remote_path: a path in a remote instance
         :return string: the translated path
         """
+        if not remote_path or "/" not in remote_path:
+            raise SyncError("error", "Invalid remote path: '{}'"
+                            .format(remote_path))
+
         if self.is_portal_path(remote_path):
             return api.get_path(self.portal)
 
@@ -73,8 +77,8 @@ class SyncStep(object):
         rem_id = utils.get_id_from_path(remote_path)
         rec = self.sh.find_unique(REMOTE_PATH, remote_path)
         if rec is None:
-            raise SyncError("Missing Remote path in Soup table: {}".format(
-                                                    remote_path))
+            raise SyncError("error", "Missing Remote path in Soup table: {}"
+                            .format(remote_path))
 
         # Check if previously translated and saved
         if rec[LOCAL_PATH]:

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -73,6 +73,9 @@ class SyncStep(object):
 
         rem_id = utils.get_id_from_path(remote_path)
         rec = self.sh.find_unique(REMOTE_PATH, remote_path)
+        if rec is None:
+            raise SyncError("Missing Remote path in Soup table: {}".format(
+                                                    remote_path))
         if rec[LOCAL_PATH]:
             return str(rec[LOCAL_PATH])
 

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -44,6 +44,7 @@ class SyncStep(object):
         self.password = data.get("ac_password", None)
         # Import configuration
         self.content_types = data.get("content_types", None)
+        self.unwanted_content_types = data.get("unwanted_content_types", None)
         self.prefix = data.get("prefix", None)
         self.prefixable_types = data.get("prefixable_types", None)
         self.import_settings = data.get("import_settings", False)

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -45,6 +45,7 @@ class SyncStep(object):
         # Import configuration
         self.content_types = data.get("content_types", None)
         self.prefix = data.get("prefix", None)
+        self.prefixable_types = data.get("prefixable_types", None)
         self.import_settings = data.get("import_settings", False)
         self.import_users = data.get("import_users", False)
         self.import_registry = data.get("import_registry", False)
@@ -94,9 +95,8 @@ class SyncStep(object):
         :param portal_type:
         :return:
         """
-        if self.prefix and portal_type == 'Client':
+        if self.prefix and portal_type in self.prefixable_types:
             return self.prefix
-
         return ""
 
     def is_portal_path(self, path):

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -44,7 +44,7 @@ class SyncStep(object):
         self.password = data.get("ac_password", None)
         # Import configuration
         self.content_types = data.get("content_types", None)
-        self.prefix = ""
+        self.prefix = data.get("prefix", None)
         self.import_settings = data.get("import_settings", False)
         self.import_users = data.get("import_users", False)
         self.import_registry = data.get("import_registry", False)
@@ -62,6 +62,9 @@ class SyncStep(object):
     def translate_path_with_prefix(self, remote_path):
         """
         """
+        if self.is_portal_path(remote_path):
+            return api.get_path(self.portal)
+
         portal_id = self.portal.getId()
         remote_portal_id = remote_path.split("/")[1]
         if not self.prefix:
@@ -91,8 +94,8 @@ class SyncStep(object):
         :param portal_type:
         :return:
         """
-        if self.prefix and portal_type == 'Analysis':
-            return "PR_"
+        if self.prefix and portal_type == 'Client':
+            return self.prefix
 
         return ""
 

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -73,7 +73,7 @@ class SyncStep(object):
         rem_id = utils.get_id_from_path(remote_path)
         rec = self.sh.find_unique(REMOTE_PATH, remote_path)
         if rec[LOCAL_PATH]:
-            return rec[LOCAL_PATH]
+            return str(rec[LOCAL_PATH])
 
         # Get parent's local path
         remote_parent_path = utils.get_parent_path(remote_path)
@@ -86,7 +86,7 @@ class SyncStep(object):
         res = "{0}/{1}{2}".format(parent_path, prefix, rem_id)
         res = res.replace(remote_portal_id, portal_id)
         self.sh.update_by_remote_path(remote_path, LOCAL_PATH = res)
-        return res
+        return str(res)
 
     def get_prefix(self, portal_type):
         """

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -15,6 +15,7 @@ from senaite import api
 from senaite.sync import logger
 from senaite.sync import utils
 from senaite.sync.syncerror import SyncError
+from senaite.sync.souphandler import REMOTE_PATH
 
 SYNC_STORAGE = "senaite.sync"
 API_BASE_URL = "API/senaite/v1"
@@ -227,7 +228,7 @@ class SyncStep(object):
         if self.is_portal_path(parent_path):
             return True
         # Skip if already exists
-        if self.sh.find_unique("path", parent_path):
+        if self.sh.find_unique(REMOTE_PATH, parent_path):
             return True
         logger.debug("Inserting missing parent: {}".format(parent_path))
         parent = self.get_first_item(item.get("parent_url"))

--- a/src/senaite/sync/utils.py
+++ b/src/senaite/sync/utils.py
@@ -31,7 +31,7 @@ def to_review_history_format(review_history):
     return review_history
 
 
-def is_item_allowed(item):
+def has_valid_portal_type(item):
     """ Check if an item can be handled based on its portal type.
     :return: True if the item can be handled
     """

--- a/src/senaite/sync/utils.py
+++ b/src/senaite/sync/utils.py
@@ -46,6 +46,24 @@ def has_valid_portal_type(item):
     return True
 
 
+def filter_content_types(content_types):
+    """
+
+    :param content_types:
+    :return:
+    """
+    ret = list()
+    if not content_types:
+        return ret
+
+    # Get available portal types and make it all lowercase
+    portal_types = api.get_tool("portal_types")
+
+    ret = [t.strip() for t in content_types.split(",") if t]
+    ret = filter(lambda ct: ct.lower() in portal_types, ret)
+    return ret
+
+
 def get_parent_path(path):
     """
     Gets the parent path for a given object path.

--- a/src/senaite/sync/utils.py
+++ b/src/senaite/sync/utils.py
@@ -58,8 +58,11 @@ def filter_content_types(content_types):
 
     # Get available portal types and make it all lowercase
     portal_types = api.get_tool("portal_types").listContentTypes()
+    portal_types = [t.lower for t in portal_types]
+
     ret = [t.strip() for t in content_types.split(",") if t]
-    ret = filter(lambda ct, types=portal_types: ct in types, ret)
+    ret = filter(lambda ct, types=portal_types: ct.lower() in types, ret)
+    ret = list(set(ret))
     return ret
 
 

--- a/src/senaite/sync/utils.py
+++ b/src/senaite/sync/utils.py
@@ -57,7 +57,9 @@ def get_parent_path(path):
     if path.endswith("/"):
         path = path[:-1]
     parts = path.split("/")
-    return "/".join(parts[:-1])
+    if len(parts) < 3:
+        return "/"
+    return str("/".join(parts[:-1]))
 
 
 def get_id_from_path(path):

--- a/src/senaite/sync/utils.py
+++ b/src/senaite/sync/utils.py
@@ -38,7 +38,7 @@ def has_valid_portal_type(item):
     if not isinstance(item, dict):
         return False
 
-    portal_types = api.get_tool("portal_types")
+    portal_types = api.get_tool("portal_types").listContentTypes()
     pt = item.get("portal_type", None)
     if pt not in portal_types:
         return False
@@ -57,10 +57,9 @@ def filter_content_types(content_types):
         return ret
 
     # Get available portal types and make it all lowercase
-    portal_types = api.get_tool("portal_types")
-
+    portal_types = api.get_tool("portal_types").listContentTypes()
     ret = [t.strip() for t in content_types.split(",") if t]
-    ret = filter(lambda ct: ct.lower() in portal_types, ret)
+    ret = filter(lambda ct, types=portal_types: ct in types, ret)
     return ret
 
 

--- a/src/senaite/sync/utils.py
+++ b/src/senaite/sync/utils.py
@@ -7,11 +7,12 @@ from senaite import api
 from senaite.sync import logger
 from DateTime import DateTime
 from datetime import datetime
+from senaite.sync.souphandler import REMOTE_UID, REMOTE_PATH, PORTAL_TYPE
 
 
-SOUPER_REQUIRED_FIELDS = {"uid": "remote_uid",
-                          "path": "path",
-                          "portal_type": "portal_type"}
+SOUPER_REQUIRED_FIELDS = {"uid": REMOTE_UID,
+                          "path": REMOTE_PATH,
+                          "portal_type": PORTAL_TYPE}
 
 SYNC_CREDENTIALS = "senaite.sync.credentials"
 


### PR DESCRIPTION
## Current behavior before PR

1. 'Adding a new Remote From' and 'Data of existing Remotes' are in the same View.
2. It is not possible to specify object types which a user doesn't want to import.
3. While importing from different remotes, objects with the same ID are _overriden_ or not being updated.

## Desired behavior after PR is merged

1. The old (`/sync`) view will only list the Fetched Data and their Actions. New (`/sync_add`) View will be available to add a new remote.
2. A new  field will be added to 'Add' form where users can define Content Types- separated by comma, to be skipped during import.
3. New 'Prefix Logic' will be introduced and users will be able to define a prefix for each remote and use them for specific content types. It will help the system to save _similar_ objects from different Remotes separately. Prefixes will be added only to object ID's so far... If Prefix is empty, it will behave in the old, standard way.


### Screenshots
Adding New Remote Form:

![image](https://user-images.githubusercontent.com/23520079/39697055-ec5319bc-51ef-11e8-940d-2e402784341a.png)

Extended Advanced Options:
![image](https://user-images.githubusercontent.com/23520079/39697064-f1176b10-51ef-11e8-840b-88cea519d613.png)

-----
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
