### PR TITLE
Advanced Configuration: 'Read-Only' Portal Types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #44 Advanced Configuration: 'Read-Only' Portal Types
 - #42 New Advanced Configuration Options
 - #34 Complement step for migration
 - #33 Recover step for failed objects in data import

--- a/src/senaite/sync/browser/add.py
+++ b/src/senaite/sync/browser/add.py
@@ -61,6 +61,8 @@ class Add(Sync):
                                         form.get("content_types"))
             unwanted_content_types = utils.filter_content_types(
                                         form.get("unwanted_content_types"))
+            read_only_types = utils.filter_content_types(
+                                        form.get("read_only_types"))
 
             prefix = form.get("prefix", None)
             prefixable_types = utils.filter_content_types(
@@ -93,6 +95,7 @@ class Add(Sync):
                 "ac_password": password,
                 "content_types": content_types,
                 "unwanted_content_types": unwanted_content_types,
+                "read_only_types": read_only_types,
                 "import_settings": import_settings,
                 "import_users": import_users,
                 "import_registry": import_registry,

--- a/src/senaite/sync/browser/templates/add.pt
+++ b/src/senaite/sync/browser/templates/add.pt
@@ -241,6 +241,28 @@
                     </div>
                   </li>
 
+                  <li class="list-group-item">
+                    <!-- Content Types to be created in Read-Only mode -->
+                    <div class="field form-group field">
+                      <label i18n:translate=""
+                             class="form-control-label"
+                             for="read_only_types">
+                        Read-Only Content Types
+                        <span i18n:translate=""
+                              class="help formHelp">
+                          Introduce Content Types to be Imported and Created in Read-Only Mode. E.g: 'Method, Department'
+                        </span>
+                      </label>
+                      <div class="form-group input-group">
+                        <input type="text"
+                               size="45"
+                               class="form-control"
+                               id="read_only_types"
+                               name="read_only_types"/>
+                      </div>
+                    </div>
+                  </li>
+
                 </ul>
               </div>
             </div>

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -72,6 +72,8 @@ class Sync(BrowserView):
                                     domain_name, "unwanted_content_types", [])
             prefixable_types = self.get_storage_config(
                                     domain_name, "prefixable_types", [])
+            read_only_types = self.get_storage_config(
+                                    domain_name, "read_only_types", [])
 
             data = {
                 "url": url,
@@ -80,6 +82,7 @@ class Sync(BrowserView):
                 "ac_password": password,
                 "content_types": content_types,
                 "unwanted_content_types": unwanted_content_types,
+                "read_only_types": read_only_types,
                 "prefix": prefix,
                 "prefixable_types": prefixable_types,
             }
@@ -117,6 +120,8 @@ class Sync(BrowserView):
                                     domain_name, "unwanted_content_types", [])
             prefixable_types = self.get_storage_config(
                                     domain_name, "prefixable_types", [])
+            read_only_types = self.get_storage_config(
+                                    domain_name, "read_only_types", [])
 
             data = {
                 "url": url,
@@ -126,6 +131,7 @@ class Sync(BrowserView):
                 "fetch_time": fetch_time,
                 "content_types": content_types,
                 "unwanted_content_types": unwanted_content_types,
+                "read_only_types": read_only_types,
                 "prefix": prefix,
                 "prefixable_types": prefixable_types,
             }

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -65,6 +65,7 @@ class FetchStep(SyncStep):
         # remember import configuration in the storage
         storage["configuration"]["content_types"] = self.content_types
         storage["configuration"]["unwanted_content_types"] = self.unwanted_content_types
+        storage["configuration"]["read_only_types"] = self.read_only_types
         storage["configuration"]["prefix"] = self.prefix
         storage["configuration"]["prefixable_types"] = self.prefixable_types
         storage["configuration"]["import_settings"] = self.import_settings

--- a/src/senaite/sync/importstep.py
+++ b/src/senaite/sync/importstep.py
@@ -282,6 +282,7 @@ class ImportStep(SyncStep):
             if handle_dependencies:
                 self._create_dependencies(obj, obj_data)
             self._update_object_with_data(obj, obj_data)
+            self._set_object_permission(obj)
             self.sh.mark_update(r_uid)
             self._queue.remove(r_uid)
         except Exception, e:
@@ -628,3 +629,17 @@ class ImportStep(SyncStep):
             obj = brain.getObject()
             obj.reindexObject()
         return
+
+    def _set_object_permission(self, obj):
+        """
+        :param obj:
+        :return:
+        """
+        portal_type = api.get_portal_type(obj)
+
+        # Don't do anything, if it is just a dependency
+        if portal_type in self.unwanted_content_types:
+            return
+
+        if portal_type in self.read_only_types:
+            obj.manage_permission('Modify portal content', roles=[])

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -45,6 +45,7 @@ class SyncStep(object):
         # Import configuration
         self.content_types = data.get("content_types", [])
         self.unwanted_content_types = data.get("unwanted_content_types", [])
+        self.read_only_types = data.get("read_only_types", [])
         self.prefix = data.get("prefix", None)
         self.prefixable_types = data.get("prefixable_types", [])
         self.import_settings = data.get("import_settings", False)


### PR DESCRIPTION
## Current behavior before PR
All objects are migrated and created with default permissions in the destination instance.


## Desired behavior after PR is merged
Let the users to define Portal Types to be imported in 'Read-Only' mode. Those objects can be modified only in the source and be updated in the destination. Although it is not useful for migration, for 'Sync' it can be necessary.


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
