### PR TITLE
Error while Fetching Missing Parents

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ Changelog
 
 **Fixed**
 
+- #45 Error while Fetching Missing Parents
 - #39 Complement Step does not update all objects
 - #35 Bug- Complement Step yields all the items
 - #35 Complement Step yields all the items

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -165,7 +165,7 @@ class SyncStep(object):
     def get_first_item(self, url_or_endpoint, **kw):
         """Fetch the first item of the 'items' list from a std. JSON API reponse
         """
-        items = self.get_items_with_retry(url_or_endpoint, **kw)
+        items = self.get_items_with_retry(url_or_endpoint=url_or_endpoint, **kw)
         if not items:
             return None
         return items[0]

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -165,7 +165,7 @@ class SyncStep(object):
     def get_first_item(self, url_or_endpoint, **kw):
         """Fetch the first item of the 'items' list from a std. JSON API reponse
         """
-        items = self.get_items(url_or_endpoint, **kw)
+        items = self.get_items_with_retry(url_or_endpoint, **kw)
         if not items:
             return None
         return items[0]
@@ -281,6 +281,9 @@ class SyncStep(object):
             return True
         logger.debug("Inserting missing parent: {}".format(parent_path))
         parent = self.get_first_item(item.get("parent_url"))
+        if not parent:
+            logger.error("Cannot fetch parent info: {} ".format(parent_path))
+            return False
         par_dict = utils.get_soup_format(parent)
         self.sh.insert(par_dict)
         # Recursively import grand parents too


### PR DESCRIPTION
## Current behavior before PR
There is no retry for HTTP requests during Parent Fetch and system raises and error when parents cannot be fetched.


## Desired behavior after PR is merged
Parent Fetch must be done with retry and just skip if not found in the source.


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
