### PR TITLE
Advanced Configuration: Local Prefix and Update only Content Types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #46 Advanced Configuration: Local Prefix and Update only Content Types
 - #44 Advanced Configuration: 'Read-Only' Portal Types
 - #42 New Advanced Configuration Options
 - #34 Complement step for migration

--- a/src/senaite/sync/browser/add.py
+++ b/src/senaite/sync/browser/add.py
@@ -63,6 +63,8 @@ class Add(Sync):
                                         form.get("unwanted_content_types"))
             read_only_types = utils.filter_content_types(
                                         form.get("read_only_types"))
+            update_only_types = utils.filter_content_types(
+                                        form.get("update_only_types"))
 
             remote_prefix = form.get("remote_prefix", None)
             local_prefix = form.get("local_prefix", None)
@@ -99,6 +101,7 @@ class Add(Sync):
                 "content_types": content_types,
                 "unwanted_content_types": unwanted_content_types,
                 "read_only_types": read_only_types,
+                "update_only_types": update_only_types,
                 "import_settings": import_settings,
                 "import_users": import_users,
                 "import_registry": import_registry,

--- a/src/senaite/sync/browser/add.py
+++ b/src/senaite/sync/browser/add.py
@@ -65,6 +65,7 @@ class Add(Sync):
                                         form.get("read_only_types"))
 
             remote_prefix = form.get("remote_prefix", None)
+            local_prefix = form.get("local_prefix", None)
             prefixable_types = utils.filter_content_types(
                                         form.get("prefixable_types"))
 
@@ -102,6 +103,7 @@ class Add(Sync):
                 "import_users": import_users,
                 "import_registry": import_registry,
                 "remote_prefix": remote_prefix,
+                "local_prefix": local_prefix,
                 "prefixable_types": prefixable_types,
             }
 

--- a/src/senaite/sync/browser/add.py
+++ b/src/senaite/sync/browser/add.py
@@ -64,23 +64,25 @@ class Add(Sync):
             read_only_types = utils.filter_content_types(
                                         form.get("read_only_types"))
 
-            prefix = form.get("prefix", None)
+            remote_prefix = form.get("remote_prefix", None)
             prefixable_types = utils.filter_content_types(
                                         form.get("prefixable_types"))
 
             # Prefix Validation
-            if prefix:
-                prefix = prefix.strip(PREFIX_SPECIAL_CHARACTERS)
-                if not prefix:
-                    self.add_status_message("Invalid Prefix!", "error")
+            if remote_prefix:
+                remote_prefix = remote_prefix.strip(PREFIX_SPECIAL_CHARACTERS)
+                if not remote_prefix:
+                    self.add_status_message("Invalid Remote Prefix!", "error")
                     return self.template()
 
-                if len(prefix) > 3:
-                    self.add_status_message("Long Prefix!", "warning")
+                if len(remote_prefix) > 3:
+                    self.add_status_message("Remote's Prefix is too long!!",
+                                            "warning")
 
                 if not prefixable_types:
                     self.add_status_message("Please enter valid Content Types "
-                                    "to be created with the Prefix.", "error")
+                                            "to be created with the Prefix.",
+                                            "error")
                     return self.template()
             else:
                 if prefixable_types:
@@ -99,7 +101,7 @@ class Add(Sync):
                 "import_settings": import_settings,
                 "import_users": import_users,
                 "import_registry": import_registry,
-                "prefix": prefix,
+                "remote_prefix": remote_prefix,
                 "prefixable_types": prefixable_types,
             }
 

--- a/src/senaite/sync/browser/templates/add.pt
+++ b/src/senaite/sync/browser/templates/add.pt
@@ -285,6 +285,30 @@
                     </div>
                   </li>
 
+                  <li class="list-group-item">
+                    <!-- Update-only Content Types -->
+                    <div class="field form-group field">
+                      <label i18n:translate=""
+                             class="form-control-label"
+                             for="update_only_types">
+                        Update-Only Content Types
+                        <span i18n:translate=""
+                              class="help formHelp">
+                          Introduce Content Types ONLY to be Updated with Remote instance changes.
+                          It means, only the objects that have been created on this instance will be updated according to the Remote Instance
+                          and objects with another origin will not be imported. E.g: 'AnalysisRequest, Sample'
+                        </span>
+                      </label>
+                      <div class="form-group input-group">
+                        <input type="text"
+                               size="45"
+                               class="form-control"
+                               id="update_only_types"
+                               name="update_only_types"/>
+                      </div>
+                    </div>
+                  </li>
+
                 </ul>
               </div>
             </div>

--- a/src/senaite/sync/browser/templates/add.pt
+++ b/src/senaite/sync/browser/templates/add.pt
@@ -220,6 +220,28 @@
                   </li>
 
                   <li class="list-group-item">
+                    <!-- Local Prefix -->
+                    <div class="field form-group field">
+                      <label i18n:translate=""
+                             class="form-control-label"
+                             for="local_prefix">
+                        Local Prefix
+                        <span i18n:translate=""
+                              class="help formHelp">
+                        Prefix which is used for this instance in the Remote
+                        </span>
+                      </label>
+                      <div class="form-group input-group">
+                        <input type="text"
+                               size="10"
+                               class="form-control"
+                               id="local_prefix"
+                               name="local_prefix"/>
+                      </div>
+                    </div>
+                  </li>
+
+                  <li class="list-group-item">
                     <!-- Content Types to be prefixified -->
                     <div class="field form-group field">
                       <label i18n:translate=""

--- a/src/senaite/sync/browser/templates/add.pt
+++ b/src/senaite/sync/browser/templates/add.pt
@@ -198,23 +198,23 @@
                   </li>
 
                   <li class="list-group-item">
-                    <!-- Prefix -->
+                    <!-- Remote Prefix -->
                     <div class="field form-group field">
                       <label i18n:translate=""
                              class="form-control-label"
-                             for="prefix">
-                        Prefix
+                             for="remote_prefix">
+                        Remote's Prefix
                         <span i18n:translate=""
                               class="help formHelp">
-                          A short prefix to appear in the Object ID's imported from this Remote.
+                          A short prefix to appear in the Object ID's imported from this Remote if necessary.
                         </span>
                       </label>
                       <div class="form-group input-group">
                         <input type="text"
                                size="10"
                                class="form-control"
-                               id="prefix"
-                               name="prefix"/>
+                               id="remote_prefix"
+                               name="remote_prefix"/>
                       </div>
                     </div>
                   </li>

--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -49,7 +49,7 @@
                                   unwanted_content_types python: view.get_storage_config(storage, 'unwanted_content_types');
                                   prefixable_types python: view.get_storage_config(storage, 'prefixable_types');"
               >
-                  <b>Prefix: <span style="font-size: medium" tal:replace="python: view.get_storage_config(storage, 'prefix', 'Not Defined')"/></b><br><br>
+                  <b>Remote Prefix: <span style="font-size: medium" tal:replace="python: view.get_storage_config(storage, 'remote_prefix', 'Not Defined')"/></b><br><br>
                   Settings will <span tal:condition="python: not view.get_storage_config(storage, 'import_settings')">NOT</span>,
                   Registry will <span tal:condition="python: not view.get_storage_config(storage, 'import_registry')">NOT</span>,
                   Users will <span tal:condition="python: not view.get_storage_config(storage, 'import_users')">NOT</span> be imported.<br><br>

--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -47,7 +47,9 @@
               <div
                       tal:define="content_types python: view.get_storage_config(storage, 'content_types');
                                   unwanted_content_types python: view.get_storage_config(storage, 'unwanted_content_types');
-                                  prefixable_types python: view.get_storage_config(storage, 'prefixable_types');"
+                                  prefixable_types python: view.get_storage_config(storage, 'prefixable_types');
+                                  read_only_types python: view.get_storage_config(storage, 'read_only_types');
+                                  update_only_types python: view.get_storage_config(storage, 'update_only_types');"
               >
                   <b>Remote's Prefix: <span style="font-size: medium" tal:replace="python: view.get_storage_config(storage, 'remote_prefix', 'Not Defined')"/></b><br><br>
                   <b>Local Prefix: <span style="font-size: medium" tal:replace="python: view.get_storage_config(storage, 'local_prefix', 'Not Defined')"/></b><br><br>
@@ -58,6 +60,8 @@
                   Content types to be imported: <b><span tal:replace="python: ', '.join(content_types) if content_types else 'All the content types'"/> </b><br><br>
                   Content types to be skipped: <b><span tal:replace="python: ', '.join(unwanted_content_types) if unwanted_content_types else 'Not specified'"/> </b><br><br>
                   Content types that will contain prefix: <b><span tal:replace="python: ', '.join(prefixable_types) if prefixable_types else 'Not defined'"/> </b><br><br>
+                  Content types that will be in read-only mode: <b><span tal:replace="python: ', '.join(read_only_types) if read_only_types else 'Not defined'"/> </b><br><br>
+                  Content types just to be updated: <b><span tal:replace="python: ', '.join(update_only_types) if update_only_types else 'Not defined'"/> </b><br><br>
               </div><br>
               <input class="btn btn-default btn-sm"
                      type="submit"

--- a/src/senaite/sync/browser/templates/sync.pt
+++ b/src/senaite/sync/browser/templates/sync.pt
@@ -49,7 +49,8 @@
                                   unwanted_content_types python: view.get_storage_config(storage, 'unwanted_content_types');
                                   prefixable_types python: view.get_storage_config(storage, 'prefixable_types');"
               >
-                  <b>Remote Prefix: <span style="font-size: medium" tal:replace="python: view.get_storage_config(storage, 'remote_prefix', 'Not Defined')"/></b><br><br>
+                  <b>Remote's Prefix: <span style="font-size: medium" tal:replace="python: view.get_storage_config(storage, 'remote_prefix', 'Not Defined')"/></b><br><br>
+                  <b>Local Prefix: <span style="font-size: medium" tal:replace="python: view.get_storage_config(storage, 'local_prefix', 'Not Defined')"/></b><br><br>
                   Settings will <span tal:condition="python: not view.get_storage_config(storage, 'import_settings')">NOT</span>,
                   Registry will <span tal:condition="python: not view.get_storage_config(storage, 'import_registry')">NOT</span>,
                   Users will <span tal:condition="python: not view.get_storage_config(storage, 'import_users')">NOT</span> be imported.<br><br>

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -65,7 +65,7 @@ class Sync(BrowserView):
             url = storage["credentials"]["url"]
             username = storage["credentials"]["username"]
             password = storage["credentials"]["password"]
-            prefix = self.get_storage_config(domain_name, "prefix", None)
+            remote_prefix = self.get_storage_config(domain_name, "remote_prefix", None)
             content_types = self.get_storage_config(
                                     domain_name, "content_types", [])
             unwanted_content_types = self.get_storage_config(
@@ -83,7 +83,7 @@ class Sync(BrowserView):
                 "content_types": content_types,
                 "unwanted_content_types": unwanted_content_types,
                 "read_only_types": read_only_types,
-                "prefix": prefix,
+                "remote_prefix": remote_prefix,
                 "prefixable_types": prefixable_types,
             }
             step = ImportStep(data)
@@ -113,7 +113,7 @@ class Sync(BrowserView):
             url = storage["credentials"]["url"]
             username = storage["credentials"]["username"]
             password = storage["credentials"]["password"]
-            prefix = self.get_storage_config(domain_name, "prefix", None)
+            remote_prefix = self.get_storage_config(domain_name, "remote_prefix", None)
             content_types = self.get_storage_config(
                                     domain_name, "content_types", [])
             unwanted_content_types = self.get_storage_config(
@@ -132,7 +132,7 @@ class Sync(BrowserView):
                 "content_types": content_types,
                 "unwanted_content_types": unwanted_content_types,
                 "read_only_types": read_only_types,
-                "prefix": prefix,
+                "remote_prefix": remote_prefix,
                 "prefixable_types": prefixable_types,
             }
             step = ComplementStep(data)

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -66,6 +66,7 @@ class Sync(BrowserView):
             username = storage["credentials"]["username"]
             password = storage["credentials"]["password"]
             remote_prefix = self.get_storage_config(domain_name, "remote_prefix", None)
+            local_prefix = self.get_storage_config(domain_name, "local_prefix", None)
             content_types = self.get_storage_config(
                                     domain_name, "content_types", [])
             unwanted_content_types = self.get_storage_config(
@@ -84,6 +85,7 @@ class Sync(BrowserView):
                 "unwanted_content_types": unwanted_content_types,
                 "read_only_types": read_only_types,
                 "remote_prefix": remote_prefix,
+                "local_prefix": local_prefix,
                 "prefixable_types": prefixable_types,
             }
             step = ImportStep(data)
@@ -114,6 +116,7 @@ class Sync(BrowserView):
             username = storage["credentials"]["username"]
             password = storage["credentials"]["password"]
             remote_prefix = self.get_storage_config(domain_name, "remote_prefix", None)
+            local_prefix = self.get_storage_config(domain_name, "local_prefix", None)
             content_types = self.get_storage_config(
                                     domain_name, "content_types", [])
             unwanted_content_types = self.get_storage_config(
@@ -133,6 +136,7 @@ class Sync(BrowserView):
                 "unwanted_content_types": unwanted_content_types,
                 "read_only_types": read_only_types,
                 "remote_prefix": remote_prefix,
+                "local_prefix": local_prefix,
                 "prefixable_types": prefixable_types,
             }
             step = ComplementStep(data)

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -75,6 +75,8 @@ class Sync(BrowserView):
                                     domain_name, "prefixable_types", [])
             read_only_types = self.get_storage_config(
                                     domain_name, "read_only_types", [])
+            update_only_types = self.get_storage_config(
+                                    domain_name, "update_only_types", [])
 
             data = {
                 "url": url,
@@ -84,6 +86,7 @@ class Sync(BrowserView):
                 "content_types": content_types,
                 "unwanted_content_types": unwanted_content_types,
                 "read_only_types": read_only_types,
+                "update_only_types": update_only_types,
                 "remote_prefix": remote_prefix,
                 "local_prefix": local_prefix,
                 "prefixable_types": prefixable_types,
@@ -125,6 +128,8 @@ class Sync(BrowserView):
                                     domain_name, "prefixable_types", [])
             read_only_types = self.get_storage_config(
                                     domain_name, "read_only_types", [])
+            update_only_types = self.get_storage_config(
+                                    domain_name, "update_only_types", [])
 
             data = {
                 "url": url,
@@ -135,6 +140,7 @@ class Sync(BrowserView):
                 "content_types": content_types,
                 "unwanted_content_types": unwanted_content_types,
                 "read_only_types": read_only_types,
+                "update_only_types": update_only_types,
                 "remote_prefix": remote_prefix,
                 "local_prefix": local_prefix,
                 "prefixable_types": prefixable_types,

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -66,6 +66,7 @@ class FetchStep(SyncStep):
         storage["configuration"]["content_types"] = self.content_types
         storage["configuration"]["unwanted_content_types"] = self.unwanted_content_types
         storage["configuration"]["read_only_types"] = self.read_only_types
+        storage["configuration"]["update_only_types"] = self.update_only_types
         storage["configuration"]["remote_prefix"] = self.remote_prefix
         storage["configuration"]["local_prefix"] = self.local_prefix
         storage["configuration"]["prefixable_types"] = self.prefixable_types

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -66,7 +66,7 @@ class FetchStep(SyncStep):
         storage["configuration"]["content_types"] = self.content_types
         storage["configuration"]["unwanted_content_types"] = self.unwanted_content_types
         storage["configuration"]["read_only_types"] = self.read_only_types
-        storage["configuration"]["prefix"] = self.prefix
+        storage["configuration"]["remote_prefix"] = self.remote_prefix
         storage["configuration"]["prefixable_types"] = self.prefixable_types
         storage["configuration"]["import_settings"] = self.import_settings
         storage["configuration"]["import_registry"] = self.import_registry

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -67,6 +67,7 @@ class FetchStep(SyncStep):
         storage["configuration"]["unwanted_content_types"] = self.unwanted_content_types
         storage["configuration"]["read_only_types"] = self.read_only_types
         storage["configuration"]["remote_prefix"] = self.remote_prefix
+        storage["configuration"]["local_prefix"] = self.local_prefix
         storage["configuration"]["prefixable_types"] = self.prefixable_types
         storage["configuration"]["import_settings"] = self.import_settings
         storage["configuration"]["import_registry"] = self.import_registry

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -46,7 +46,7 @@ class SyncStep(object):
         self.content_types = data.get("content_types", [])
         self.unwanted_content_types = data.get("unwanted_content_types", [])
         self.read_only_types = data.get("read_only_types", [])
-        self.prefix = data.get("prefix", None)
+        self.remote_prefix = data.get("remote_prefix", None)
         self.prefixable_types = data.get("prefixable_types", [])
         self.import_settings = data.get("import_settings", False)
         self.import_users = data.get("import_users", False)
@@ -72,7 +72,7 @@ class SyncStep(object):
 
         portal_id = self.portal.getId()
         remote_portal_id = remote_path.split("/")[1]
-        if not self.prefix:
+        if not self.remote_prefix:
             return str(remote_path.replace(remote_portal_id, portal_id))
 
         rem_id = utils.get_id_from_path(remote_path)
@@ -104,8 +104,8 @@ class SyncStep(object):
         :param portal_type: content type to get the prefix for
         :return:
         """
-        if self.prefix and portal_type in self.prefixable_types:
-            return self.prefix
+        if self.remote_prefix and portal_type in self.prefixable_types:
+            return self.remote_prefix
         return ""
 
     def is_portal_path(self, path):

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -319,7 +319,8 @@ class SyncStep(object):
         # If it is update-only content type, then Remote Id should start with
         # this instance's prefix
         if pt in self.update_only_types:
-            remote_id= item.get("id", "")
+            remote_path= item.get("path", "")
+            remote_id = utils.get_id_from_path(remote_path)
             if not remote_id.startswith(self.local_prefix):
                 return False
 

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -298,7 +298,15 @@ class SyncStep(object):
         """
         if not utils.has_valid_portal_type(item):
             return False
-        if item.get("portal_type") in self.unwanted_content_types:
+        pt = item.get("portal_type")
+        if pt in self.unwanted_content_types:
             return False
+
+        # If it is update-only content type, then Remote Id should start with
+        # this instance's prefix
+        if pt in self.update_only_types:
+            remote_id= item.get("id", "")
+            if not remote_id.startswith(self.local_prefix):
+                return False
 
         return True

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -46,6 +46,7 @@ class SyncStep(object):
         self.content_types = data.get("content_types", [])
         self.unwanted_content_types = data.get("unwanted_content_types", [])
         self.read_only_types = data.get("read_only_types", [])
+        self.update_only_types = data.get("update_only_types", [])
         self.remote_prefix = data.get("remote_prefix", None)
         self.local_prefix = data.get("local_prefix", None)
         self.prefixable_types = data.get("prefixable_types", [])

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -47,6 +47,7 @@ class SyncStep(object):
         self.unwanted_content_types = data.get("unwanted_content_types", [])
         self.read_only_types = data.get("read_only_types", [])
         self.remote_prefix = data.get("remote_prefix", None)
+        self.local_prefix = data.get("local_prefix", None)
         self.prefixable_types = data.get("prefixable_types", [])
         self.import_settings = data.get("import_settings", False)
         self.import_users = data.get("import_users", False)

--- a/src/senaite/sync/utils.py
+++ b/src/senaite/sync/utils.py
@@ -60,7 +60,7 @@ def filter_content_types(content_types):
 
     # Get available portal types and make it all lowercase
     portal_types = api.get_tool("portal_types").listContentTypes()
-    portal_types = [t.lower for t in portal_types]
+    portal_types = [t.lower() for t in portal_types]
 
     ret = [t.strip() for t in content_types.split(",") if t]
     ret = filter(lambda ct, types=portal_types: ct.lower() in types, ret)


### PR DESCRIPTION
## Current behavior before PR
1. If more than 2 Instance's are synchronized, prefixes are not taken into account and there can be object repetition.

## Desired behavior after PR is merged
1. By using 'Local Prefix'- which lets users introduce **'The Prefix used for the current instance in the Remote'**, this problem will be solved. 
2. Users can define Content Types which they just want to have updates of.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
