### PR TITLE
More User Friendly Interface

### DIFF
--- a/src/senaite/sync/browser/configure.zcml
+++ b/src/senaite/sync/browser/configure.zcml
@@ -23,4 +23,11 @@
       permission="cmf.ManagePortal"
       />
 
+  <browser:page
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      name="sync_content_types"
+      class=".views.ContentTypesView"
+      permission="cmf.ManagePortal"
+      />
+
 </configure>

--- a/src/senaite/sync/browser/templates/add.pt
+++ b/src/senaite/sync/browser/templates/add.pt
@@ -348,7 +348,7 @@
             </div>
           </div>
         </div>
-
+        <a target="_blank" href="sync_content_types"> Click here to list all the available Content Types.</a><br><br><br>
         <input class="btn btn-success btn-sm allowMultiSubmit"
                type="submit"
                name="fetch"

--- a/src/senaite/sync/browser/templates/content_types.pt
+++ b/src/senaite/sync/browser/templates/content_types.pt
@@ -2,13 +2,27 @@
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       i18n:domain="senaite">
-  <head>
+<head>
 
-  </head>
-  <body>
-    <tal:ct repeat="content_type view/get_content_types">
-        <span tal:replace="content_type"/>
-        <br>
-    </tal:ct>
-  </body>
+</head>
+<body tal:define="types view/get_content_types;
+                  total python: len(types)">
+    <table border="1">
+            <tr>
+                <tal:col repeat="col python: range(total)">
+                    <td tal:condition="python: not col % 30" >
+                        <table>
+                            <tal:row repeat="row python: range(30)">
+                                <tr tal:attributes="style python: 'background-color: aliceblue' if row % 2 else '';">
+                                    <td style="vertical-align:top; padding-right: 80px;">
+                                        <span tal:replace="python: types[row+col] if row+col < total else '' "/><br>
+                                    </td>
+                                </tr>
+                            </tal:row>
+                        </table>
+                    </td>
+                </tal:col>
+            </tr>
+    </table>
+</body>
 </html>

--- a/src/senaite/sync/browser/templates/content_types.pt
+++ b/src/senaite/sync/browser/templates/content_types.pt
@@ -1,0 +1,14 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      i18n:domain="senaite">
+  <head>
+
+  </head>
+  <body>
+    <tal:ct repeat="content_type view/get_content_types">
+        <span tal:replace="content_type"/>
+        <br>
+    </tal:ct>
+  </body>
+</html>

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -139,3 +139,20 @@ class Sync(BrowserView):
         if annotation.get(SYNC_STORAGE) is None:
             annotation[SYNC_STORAGE] = OOBTree()
         return annotation[SYNC_STORAGE]
+
+
+class ContentTypesView:
+    """Sync Controller View
+    """
+
+    template = ViewPageTemplateFile("templates/content_types.pt")
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def __call__(self):
+        return self.template()
+
+    def get_content_types(self):
+        return api.get_tool("portal_types").listContentTypes()

--- a/src/senaite/sync/browser/views.py
+++ b/src/senaite/sync/browser/views.py
@@ -142,7 +142,7 @@ class Sync(BrowserView):
 
 
 class ContentTypesView:
-    """Sync Controller View
+    """ A view to list all the Content Types existing on the portal.
     """
 
     template = ViewPageTemplateFile("templates/content_types.pt")

--- a/src/senaite/sync/profiles/default/actions.xml
+++ b/src/senaite/sync/profiles/default/actions.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+	name="portal_actions"
+	meta_type="Plone Actions Tool"
+	purge="True">
+
+	<action-provider name="portal_actions"/>
+	<object name="portal_tabs" meta_type="CMF Action Category">
+		<object name="sync" meta_type="CMF Action" i18n:domain="plone">
+			<property name="title" i18n:translate="">SYNC</property>
+			<property name="description" i18n:translate=""/>
+			<property name="url_expr">string:$portal_url/sync</property>
+			<property name="link_target"/>
+			<property name="icon_expr"/>
+			<property name="available_expr"/>
+			<property name="permissions">
+				<element value="Manage Portal"/>
+			</property>
+			<property name="visible">True</property>
+		</object>
+	</object>
+</object>


### PR DESCRIPTION
## Current behavior before PR
1. In order to go to Sync Views, users have to type exact URL.
2. While Introducing Content Types for any field from Advanced Configuration, users are not able to see the full list of the available Content Types.

## Desired behavior after PR is merged
1. Add 'SYNC' to Portal Tab Menu.
2. A very basic page- which users can access directly from 'Add Remote' view, to show all the Content Types existing in the instance.


## Screenshots

**Link to Sync in Portal Tab:**
![image](https://user-images.githubusercontent.com/23520079/40535364-30dfd1b6-6009-11e8-91ee-65031298e956.png)


-----

**Link to show Content Types:**
![image](https://user-images.githubusercontent.com/23520079/40535583-c976f116-6009-11e8-85fb-99fd7e71e893.png)

-----

**Content Types Table:**
![image](https://user-images.githubusercontent.com/23520079/40535506-9c2ce6a2-6009-11e8-9eed-88907188dcb4.png)

-------
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
