### PR TITLE
Long term infinite loops in Update Step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Changelog
 
 **Fixed**
 
+- #50 Long term infinite loops in Update Step
 - #48 Auto Synchronization
 - #45 Error while Fetching Missing Parents
 - #39 Complement Step does not update all objects

--- a/src/senaite/sync/updatestep.py
+++ b/src/senaite/sync/updatestep.py
@@ -6,6 +6,8 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
 from datetime import datetime
+
+import transaction
 from DateTime import DateTime
 
 from senaite import api
@@ -34,6 +36,7 @@ class UpdateStep(ImportStep):
         """
         self.session = self.get_session()
         self._fetch_data()
+        transaction.commit()
         self._create_new_objects()
         self._update_objects()
         self.restore_modification_dates()

--- a/src/senaite/sync/updatestep.py
+++ b/src/senaite/sync/updatestep.py
@@ -209,7 +209,7 @@ class UpdateStep(ImportStep):
 
         self.sh = SoupHandler(self.domain_name)
 
-        for rec_id in self.records:
+        for idx, rec_id in enumerate(self.records):
             row = self.sh.get_record_by_id(rec_id, as_dict=True)
             try:
                 if row:
@@ -217,6 +217,9 @@ class UpdateStep(ImportStep):
             except Exception, e:
                 logger.error("Object creation failed for: {} ... {}".
                              format(row, str(e)))
+            if (idx % 500) == 0:
+                transaction.commit()
+                logger.info(" {} objects created.".format(idx))
         logger.info("***OBJ CREATION FINISHED: {} ***".format(self.domain_name))
         return
 

--- a/src/senaite/sync/utils.py
+++ b/src/senaite/sync/utils.py
@@ -135,7 +135,7 @@ def is_review_history_imported(obj, review_history, wf_tool=None):
     time = DateTime(review_history.get('time'))
     current_rh = wf_tool.getInfoFor(obj, 'review_history', '')
     for rh in current_rh:
-        if rh.get(state_variable) == state and time < rh.get('time'):
+        if rh.get(state_variable) == state and time <= rh.get('time'):
             return True
 
     return False

--- a/src/senaite/sync/utils.py
+++ b/src/senaite/sync/utils.py
@@ -149,41 +149,6 @@ def get_annotation(portal):
     return IAnnotations(portal)
 
 
-def get_credentials_storage(portal):
-    """
-    Credentials for domains to be used for Auto Sync are stored in a different
-    annotation. Required parameters for each domain are following:
-        -domain_name:   Unique name for the domain,
-        -url:           URL of the remote instance,
-        -ac_username:   Username to log in the remote instance,
-        -ac_password:   Unique name for the domain,
-
-    Credentials are saved in a OOBTree with the structure as in the example:
-    E.g:
-        {
-            'server_1': {
-                        'url': 'http://localhost:8080/Plone/',
-                        'ac_username': 'lab_man',
-                        'ac_password': 'lab_man',
-                        'domain_name': 'server_1',
-                        },
-            'client_1': {
-                        'url': 'http://localhost:9090/Plone/',
-                        'ac_username': 'admin',
-                        'ac_password': 'admin',
-                        'domain_name': 'client_1',
-                        },
-        }
-
-    :param portal: Portal object.
-    :return:
-    """
-    annotation = get_annotation(portal)
-    if not annotation.get(SYNC_CREDENTIALS):
-        annotation[SYNC_CREDENTIALS] = OOBTree()
-    return annotation[SYNC_CREDENTIALS]
-
-
 def log_process(task_name, started, processed, total, frequency=1):
     """Logs the current status of the process
     :param task_name: name of the task

--- a/src/senaite/sync/utils.py
+++ b/src/senaite/sync/utils.py
@@ -240,7 +240,7 @@ def date_to_query_literal(date, date_format=_default_date_format):
     if isinstance(date, basestring):
         date = datetime.strptime(date, date_format)
 
-    days = (datetime.now() - date).days
+    days = (datetime.now() - date.replace(tzinfo=None)).days
 
     if days < 1:
         return "today"


### PR DESCRIPTION
## Current behavior before PR
If two instances are synchronized and there are objects that are updated on one of the instances, then these objects will be handled in Sync processes from both sides forever. It happens because while synchronizing from the source, in the destination instance 'modified' time gets updated. Later when the source runs Sync, the destination sends these objects as recently modified objects and so on. 


## Desired behavior after PR is merged
Modification times are not 'overriden' in Update Step, so only local changes will be sent to Remotes.  


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
