### PR TITLE
Update API base url

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,8 @@ Changelog
 
 **Changed**
 
-- 43 Querying last modified objects directly from 'uid_catalog'
+- #53 Update API base url
+- #43 Querying last modified objects directly from 'uid_catalog'
 
 **Removed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #56 Allow to specify the certificate to be used when connecting to the source instance
 - #46 Advanced Configuration: Local Prefix and Update only Content Types
 - #44 Advanced Configuration: 'Read-Only' Portal Types
 - #42 New Advanced Configuration Options

--- a/src/senaite/sync/browser/add.py
+++ b/src/senaite/sync/browser/add.py
@@ -49,6 +49,7 @@ class Add(Sync):
         self.domain_name = form.get("domain_name", None)
         self.username = form.get("ac_name", None)
         self.password = form.get("ac_password", None)
+        self.certificate_file = form.get("certificate_file", None)
 
         # check if all mandatory fields have values
         if not all([self.domain_name, self.url, self.username, self.password]):
@@ -84,7 +85,8 @@ class Add(Sync):
             url=self.url,
             domain_name=self.domain_name,
             ac_name=self.username,
-            ac_password=self.password)
+            ac_password=self.password,
+            certificate_file=self.certificate_file)
 
         config = dict(
             auto_sync=self.auto_sync,

--- a/src/senaite/sync/browser/templates/add.pt
+++ b/src/senaite/sync/browser/templates/add.pt
@@ -76,6 +76,28 @@
           </div>
         </div>
 
+        <!-- Certificate file -->
+        <div class="field form-group field">
+          <label i18n:translate=""
+                 class="form-control-label"
+                 for="certificate_file">
+            Certificate path
+            <span i18n:translate=""
+                  class="help formHelp">
+                If required, the full path to the public certificate file
+            </span>
+          </label>
+          <div class="form-group input-group">
+            <span class="input-group-addon"><i class="glyphicon glyphicon-file"></i></span>
+            <input type="text" size="30"
+                   class="form-control"
+                   id="certificate_file"
+                   name="certificate_file"
+                   tal:attributes="value python: view._get_attr('certificate_file', '');"
+            />
+          </div>
+        </div>
+
         <!-- Username -->
         <div class="field form-group field">
           <label i18n:translate=""

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -45,6 +45,7 @@ class SyncStep(object):
         self.url = credentials.get("url", None)
         self.username = credentials.get("ac_name", None)
         self.password = credentials.get("ac_password", None)
+        self.certificate_file = credentials.get("certificate_file", None)
 
         if not any([self.domain_name, self.url, self.username, self.password]):
             self.fail("Missing parameter in Sync Step: {}".format(credentials))
@@ -247,6 +248,10 @@ class SyncStep(object):
         """Return a session object for authenticated requests
         """
         session = requests.Session()
+        # if a certificate path has been specified
+        #  use it for this session
+        if self.certificate_file:
+            session.verify = self.certificate_file
         session.auth = (self.username, self.password)
         return session
 

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -21,7 +21,7 @@ from senaite.sync.syncerror import SyncError
 from senaite.sync.souphandler import REMOTE_PATH, LOCAL_PATH, PORTAL_TYPE
 
 SYNC_STORAGE = "senaite.sync"
-API_BASE_URL = "API/senaite/v1"
+API_BASE_URL = "@@API/senaite/v1"
 # Sometimes we might want to send the request to the source until we get the
 # response
 API_MAX_ATTEMPTS = 5


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Although the way in which `sneaite.sync` queries senaite's json API is valid, the proper route to do so is `@@API/senaite/v1` instead of `API/senaite/v1`.

Furthermore, when setting up a vm via `senaite.ansible-palybook` incoming API requests are detected checking if `@@API` is contained in the uri. 

See [here](https://github.com/senaite/senaite.ansible-playbook/blob/8e73c2428736dd54b38d037f30acfa9751e7b91e/templates/custom_vhosts.conf.j2#L14) and [here](https://github.com/senaite/senaite.ansible-playbook/blob/8e73c2428736dd54b38d037f30acfa9751e7b91e/templates/administrative.conf.j2#L38).


## Current behavior before PR

API base url is set to `API/senaite/v1`

## Desired behavior after PR is merged

API base url is set to `@@API/senaite/v1`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
