### PR TITLE
Update sync's sessions certificate search location

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Changelog
 
 **Fixed**
 
+- #55 Sync's certificates search location so that syncronization over https works
 - #50 Long term infinite loops in Update Step
 - #48 Auto Synchronization
 - #45 Error while Fetching Missing Parents

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -26,6 +26,8 @@ API_BASE_URL = "API/senaite/v1"
 # response
 API_MAX_ATTEMPTS = 5
 API_ATTEMPT_INTERVAL = 5
+# Certificates path
+CUSTOM_CA_DIR = "/etc/ssl/certs"
 
 
 class SyncStep(object):
@@ -247,6 +249,7 @@ class SyncStep(object):
         """Return a session object for authenticated requests
         """
         session = requests.Session()
+        session.verify = CUSTOM_CA_DIR
         session.auth = (self.username, self.password)
         return session
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The Python package [`requests`](https://github.com/requests/requests), which is the one used by `senaite.sync` to perform requests uses [`certifi`](https://github.com/certifi/python-certifi)'s package CA bundle as the [default one](https://github.com/requests/requests/blob/ef88b9faa6d73bc83a07ddebc424c551d2ee671c/requests/certs.py#L8).  

Hence, when trying to sync two instances over `https` with a self signed certificate the error `[SSL: CERTIFICATE_VERIFY_FAILED]` is raised.

## Current behavior before PR

When trying to sync two instances over `https` with a self signed certificate the error `[SSL: CERTIFICATE_VERIFY_FAILED]` is raised.

## Desired behavior after PR is merged

When creating a new sync session, instead of looking for certificates in the default CA bundle,  sync searches for them in `/etc/ssl/certs`. Assuming the self signed certificate `.crt` file has been properly configured and can be found on `/etc/ssl/certs` then syncronizing two instances over `https` behaves as expected.

**Note**: To configure your system so that the new certificate can be found on `/etc/ssl/certs`:
1- Place your `.crt` file in `/usr/local/share/ca-certificates`
2- Ensure its permissions are 644 (`$ sudo chmod 644 <FILENAME>.crt`)
3- Update list of CA certificates: `$ sudo update-ca-certificates`.


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
