### PR TITLE
Allow to specify the certificate to be used 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #56 Allow to specify the certificate to be used when connecting to the source instance
 - #46 Advanced Configuration: Local Prefix and Update only Content Types
 - #44 Advanced Configuration: 'Read-Only' Portal Types
 - #42 New Advanced Configuration Options

--- a/src/senaite/sync/browser/add.py
+++ b/src/senaite/sync/browser/add.py
@@ -49,6 +49,7 @@ class Add(Sync):
         self.domain_name = form.get("domain_name", None)
         self.username = form.get("ac_name", None)
         self.password = form.get("ac_password", None)
+        self.certificate_file = form.get("certificate_file", None)
 
         # check if all mandatory fields have values
         if not all([self.domain_name, self.url, self.username, self.password]):
@@ -84,7 +85,8 @@ class Add(Sync):
             url=self.url,
             domain_name=self.domain_name,
             ac_name=self.username,
-            ac_password=self.password)
+            ac_password=self.password,
+            certificate_file=self.certificate_file)
 
         config = dict(
             auto_sync=self.auto_sync,

--- a/src/senaite/sync/browser/templates/add.pt
+++ b/src/senaite/sync/browser/templates/add.pt
@@ -76,6 +76,28 @@
           </div>
         </div>
 
+        <!-- Certificate file -->
+        <div class="field form-group field">
+          <label i18n:translate=""
+                 class="form-control-label"
+                 for="certificate_file">
+            Certificate path
+            <span i18n:translate=""
+                  class="help formHelp">
+                If required, the full path to the public certificate file
+            </span>
+          </label>
+          <div class="form-group input-group">
+            <span class="input-group-addon"><i class="glyphicon glyphicon-file"></i></span>
+            <input type="text" size="30"
+                   class="form-control"
+                   id="certificate_file"
+                   name="certificate_file"
+                   tal:attributes="value python: view._get_attr('certificate_file', '');"
+            />
+          </div>
+        </div>
+
         <!-- Username -->
         <div class="field form-group field">
           <label i18n:translate=""

--- a/src/senaite/sync/syncstep.py
+++ b/src/senaite/sync/syncstep.py
@@ -45,6 +45,7 @@ class SyncStep(object):
         self.url = credentials.get("url", None)
         self.username = credentials.get("ac_name", None)
         self.password = credentials.get("ac_password", None)
+        self.certificate_file = credentials.get("certificate_file", None)
 
         if not any([self.domain_name, self.url, self.username, self.password]):
             self.fail("Missing parameter in Sync Step: {}".format(credentials))
@@ -247,6 +248,10 @@ class SyncStep(object):
         """Return a session object for authenticated requests
         """
         session = requests.Session()
+        # if a certificate path has been specified
+        #  use it for this session
+        if self.certificate_file:
+            session.verify = self.certificate_file
         session.auth = (self.username, self.password)
         return session
 


### PR DESCRIPTION
This P.R. supersedes #55 

## Description of the issue/feature this PR addresses

**Disclaimer**: This is my understanding of the problem and I might be wrong on some points.

On one hand, the Python package [`requests`](https://github.com/requests/requests), which is the one used by `senaite.sync` to perform requests, uses [`certifi`](https://github.com/certifi/python-certifi)'s package CA bundle as the [default one](https://github.com/requests/requests/blob/ef88b9faa6d73bc83a07ddebc424c551d2ee671c/requests/certs.py#L8) when trying to validate the identity of a server.   

On the other hand, we use self-signed certificates to access over `https` instances in a local network that are not accessible through the public Internet. Why? Because CA entities such as [Let's Encrypt](https://letsencrypt.org/) only sign certificates for hosts with a valid DNS that can be accessed through the public Internet (https://community.letsencrypt.org/t/certificates-for-hosts-on-private-networks/174/7).

Hence, when trying to sync two instances over `https` with a self signed certificate `requests` fails with the error `[SSL: CERTIFICATE_VERIFY_FAILED]` because the self-signed certificate being used to access the instance over `https` hasn't been signed by any of the CA entities that the package trusts.

The solution is to explicitly tell `requests` [which certificate is to be used for validation](https://stackoverflow.com/a/30405972/2156527).

## Current behavior before PR

There wasn't an option to specify a custom certificate for `https` validation.

## Desired behavior after PR is merged

There is an option to specify a custom certificate for `https` validation. If specified, sync will use that certificate when connecting to the source instance. If it is left empty, then the default `requests` CA bundle will be used.

## Screenshot (optional)

![seleccio_001](https://user-images.githubusercontent.com/9968427/42584102-bcace58c-8532-11e8-9f1f-9f8f1b382710.png)
 


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
