### PR TITLE
Handle JSON API errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,7 +30,7 @@ Changelog
 
 **Fixed**
 
-- #57 Handle errors in API resonse when fetching data for updates
+- #57 Handle errors in API resonse when fetching data
 - #50 Long term infinite loops in Update Step
 - #48 Auto Synchronization
 - #45 Error while Fetching Missing Parents

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Changelog
 
 **Fixed**
 
+- #57 Handle errors in API resonse when fetching data for updates
 - #50 Long term infinite loops in Update Step
 - #48 Auto Synchronization
 - #45 Error while Fetching Missing Parents

--- a/src/senaite/sync/fetchstep.py
+++ b/src/senaite/sync/fetchstep.py
@@ -119,6 +119,15 @@ class FetchStep(SyncStep):
         # Knowing the catalog length compute the number of pages we will need
         # with the desired window size and overlap
         effective_window = window-overlap
+        # When we receive an error message in JSON response or we
+        # don't get any response at all the key 'count' doesn't exist.
+        if not cd.get("count", None):
+            error_message = "Error message: {}".format(cd.get('message', None) or '')
+            logger.error(
+                "A query to the JSON API returned and error. {}".format(error_message)
+            )
+            return
+
         number_of_pages = (cd["count"]/effective_window) + 1
         # Retrieve data from catalog in batches with size equal to window,
         # format it and insert it into the import soup

--- a/src/senaite/sync/updatestep.py
+++ b/src/senaite/sync/updatestep.py
@@ -74,8 +74,9 @@ class UpdateStep(ImportStep):
         # When we receive an error message in JSON response or we
         # don't get any response at all the key 'count' doesn't exist.
         if not cd.get("count", None):
+            error_message = "Error message: {}".format(cd.get('message', "")) if cd.get('message', None) else ""
             logger.error(
-                "The query returned and error. Error message: {}".format(cd.get('message', ""))
+                "A query to the JSON API returned and error. {}".format(error_message)
             )
             return
 

--- a/src/senaite/sync/updatestep.py
+++ b/src/senaite/sync/updatestep.py
@@ -71,6 +71,14 @@ class UpdateStep(ImportStep):
         window = 500
         overlap = 5
         effective_window = window-overlap
+        # When we receive an error message in JSON response or we
+        # don't get any response at all the key 'count' doesn't exist.
+        if not cd.get("count", None):
+            logger.error(
+                "The query returned and error. Error message: {}".format(cd.get('message', ""))
+            )
+            return
+
         number_of_pages = (cd["count"]/effective_window) + 1
         # Retrieve data from catalog in batches with size equal to window,
         # format it and insert it into the import soup

--- a/src/senaite/sync/updatestep.py
+++ b/src/senaite/sync/updatestep.py
@@ -74,7 +74,7 @@ class UpdateStep(ImportStep):
         # When we receive an error message in JSON response or we
         # don't get any response at all the key 'count' doesn't exist.
         if not cd.get("count", None):
-            error_message = "Error message: {}".format(cd.get('message', "")) if cd.get('message', None) else ""
+            error_message = "Error message: {}".format(cd.get('message', None) or '')
             logger.error(
                 "A query to the JSON API returned and error. {}".format(error_message)
             )


### PR DESCRIPTION
Supersedes #52 
## Description of the issue/feature this PR addresses

Linked issue: #51 

## Current behavior before PR

When a query to the JSON API for fetching data is not successful (either an error response is received or no response is received at all) then getting the value of the key `count` from the response raises an error:

https://github.com/senaite/senaite.sync/blob/bee2388eaa6300404653833d00081cf0a6065e23/src/senaite/sync/updatestep.py#L74 

https://github.com/senaite/senaite.sync/blob/d029f39bc958cff11855de4f2031fb7e22f73acd/src/senaite/sync/fetchstep.py#L122

Error message:
```
We’re sorry, but there seems to be an error…

Here is the full error message:

Display traceback as text

Traceback (innermost last):

     Module ZPublisher.Publish, line 138, in publish
     Module ZPublisher.mapply, line 77, in mapply
     Module ZPublisher.Publish, line 48, in call_object
     Module senaite.sync.browser.views, line 95, in __call__
     Module senaite.sync.updatestep, line 34, in run
     Module senaite.sync.updatestep, line 68, in _fetch_data

KeyError: 'count' 
```

## Desired behavior after PR is merged

When receiveing an error response or no response at all log the error and return without raising an exception. Note that we are logging the response error message. We can be sure that if the API response contains an error message the key `message` will exist due to: https://github.com/senaite/senaite.jsonapi/blob/871959f4b1c9edbb477e9456325527ca78e13ec6/src/senaite/jsonapi/exceptions.py#L11

  


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
