### PR TITLE
Update project description in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,14 @@ setup(
     name='senaite.sync',
     version=version,
     description="SENAITE SYNC",
-    long_description="Changelog\n" +
-                     "=========\n" +
-                     open("docs/Changelog.rst").read() + "\n" +
+    long_description=open("README.rst").read() + "\n" +
+                     open("CHANGES.rst").read() + "\n" +
                      "\n\n" +
                      "Authors and maintainers\n" +
                      "-----------------------\n\n" +
-                     "- Ramon Bartl (RIDING BYTES) <rb@ridingbytes.com>",
+                     "- Nihad Mammadli\n" +
+                     "- Ramon Bartl (RIDING BYTES) <rb@ridingbytes.com>\n" +
+                     "- Juan Gallostra (naralabs) <jgallostra@naralabs.com>",
     # Get more strings from
     # http://pypi.python.org/pypi?:action=list_classifiers
     classifiers=[


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Required modifications to prepare the first release of  `senaite.sync`.

## Current behavior before PR

The project description in `setup.py` didn't include the README file and the changelog path and file name were obsolete.

## Desired behavior after PR is merged

The `long_description` in `setup.py` will render the README + CHANGES contents. 

Also, update authors and contributors of `senaite.sync`


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
